### PR TITLE
Fix Firefox/Chrome bug with TinyMCE

### DIFF
--- a/core/components/migx/templates/mgr/fields.tpl
+++ b/core/components/migx/templates/mgr/fields.tpl
@@ -134,6 +134,34 @@ Ext.onReady(function() {
     });
 	{/literal}{if $tvcount GT 0}{literal}
     {/literal}{/if}{literal}
+
+
+    if (typeof(Tiny) != 'undefined') {
+        var s={};
+        if (Tiny.config){
+            s = Tiny.config || {};
+            delete s.assets_path;
+            delete s.assets_url;
+            delete s.core_path;
+            delete s.css_path;
+            delete s.editor;
+            delete s.id;
+            delete s.mode;
+            delete s.path;
+            s.cleanup_callback = "Tiny.onCleanup";
+            var z = Ext.state.Manager.get(MODx.siteId + '-tiny');
+            if (z !== false) {
+                delete s.elements;
+            }
+        }
+        s.mode = "specific_textareas";
+//        console.log('s', s);
+        s.editor_selector = "modx-richtext";
+        //s.language = "en";// de seems not to work at the moment
+
+        tinyMCE.init(s);
+    }
+
 });    
 // ]]>
 </script>


### PR DESCRIPTION
Hi,

this /should/ fix a bug with firefox/Chrome when using tinyMCE.
With Chrome, the content of the tinyMCE editor is randomy not saved.
With some version of Firefox, tinyMCE simply crashes the whole thing.

What I did is:
- change the first line of migx.tpl (I think I revert it back to the previous version). Don't know why it was not working, that's very minor and probably independant, I'll let you fix it back
- move the tinyMCE initialization to the processor part, so it only initializes once all the DOM is loaded. Also, there is now only one initilaization.
- add a "removeTinyMCE" method, that basically removes all the instance of tinyMCE started by MIGX, by simply telling MIGX to not screen them anymore (no more triggerSave or other stuff that was randomly breaking with Firefox).

TinyMCE is voodoo stuff, it seems to work, but I don't know why it was not working before.  

I tested it with Chrome and Firefox, and it /seems/ to work. Now, since it was a random bug, it's hard to tell if it is fixed (other correction only decrease the probability of failures), but at least I can resume working on content edition now. Please test that before merging it.

It notably fixes the infamous "NS_ERROR_UNEXPECTED: Component returned failure code: 0x8000ffff (NS_ERROR_UNEXPECTED) [nsIDOMHTMLDocument.implementation]" error with firefox (that I paste here mostly to help other users with the same problem) as discussed in http://forums.modx.com/thread/79760/possible-bug-with-tinymce-in-combination-with-migx-migxdb?page=2
