### PR TITLE
Array access warning with configless tvs

### DIFF
--- a/core/components/migx/elements/snippets/snippet.getImagelist.php
+++ b/core/components/migx/elements/snippets/snippet.getImagelist.php
@@ -78,13 +78,14 @@ if (!empty($tvname)) {
         */
 
 
-        $properties = $tv->get('input_properties');
-        $properties = isset($properties['formtabs']) ? $properties : $tv->getProperties();
-
-        $migx->config['configs'] = $properties['configs'];
-        $migx->loadConfigs();
-        // get tabs from file or migx-config-table
-        $formtabs = $migx->getTabs();
+        if (isset($properties['formtabs']) && !empty($properties['formtabs'])) {
+            $formtabs = $properties['formtabs'];
+        } else {
+            $migx->config['configs'] = $properties['configs'];
+            $migx->loadConfigs();
+            // get tabs from file or migx-config-table
+            $formtabs = $migx->getTabs();
+        }
         if (empty($formtabs)) {
             //try to get formtabs and its fields from properties
             $formtabs = $modx->fromJSON($properties['formtabs']);

--- a/core/components/migx/model/migx/migx.class.php
+++ b/core/components/migx/model/migx/migx.class.php
@@ -842,7 +842,7 @@ class Migx {
         $controller->setPlaceholder('migx_lang', $this->modx->toJSON($this->migxlang));
         $controller->setPlaceholder('properties', $properties);
         $controller->setPlaceholder('resource', $resource);
-        $controller->setPlaceholder('configs', $this->config['configs']);
+        $controller->setPlaceholder('configs', isset($this->config['configs']) ? $this->config['configs'] : array());
         $controller->setPlaceholder('reqConfigs', $this->modx->getOption('configs', $_REQUEST, ''));
         $controller->setPlaceholder('object_id', $this->modx->getOption('object_id', $_REQUEST, ''));
         $controller->setPlaceholder('reqTempParams', $this->modx->getOption('tempParams', $_REQUEST, ''));


### PR DESCRIPTION
I just stumbled over a PHP error notice trying to access an undefined array element when working with TVs without a config (storing the config directly in the TV itself). See this forum discussion for details:

http://forums.modx.com/thread/81213/undefined-index-sourcefrom-after-core-update#dis-post-447613

This fixes it for me and shouldn't break anything else.
