### PR TITLE
Unix timestamp passed to this.renderDate

### DIFF
--- a/core/components/migx/configs/grid/grid.config.inc.php
+++ b/core/components/migx/configs/grid/grid.config.inc.php
@@ -475,7 +475,11 @@ $renderer['this.renderDate'] = "
 renderDate : function(val, md, rec, row, col, s) {
     var date;
 	if (val && val != '') {
-		date = Date.parseDate(val, 'Y-m-d H:i:s');
+        if (typeof val == 'number') {
+            date = new Date(val*1000);
+        } else {
+			date = Date.parseDate(val, 'Y-m-d H:i:s');
+        }
         if (typeof(date) != 'undefined' ){
 		    return String.format('{0}', date.format(MODx.config.manager_date_format+' '+MODx.config.manager_time_format));
         }    


### PR DESCRIPTION
This commit makes it possible to use a unix timestamp as val for the renderDate renderer, have a scenario where I have only a timestamp and not a date string, without this, it isn't rendered in the migxdb grid.
