### PR TITLE
Fixing grid from breaking with null + renderImage

### DIFF
--- a/core/components/migx/configs/grid/grid.config.inc.php
+++ b/core/components/migx/configs/grid/grid.config.inc.php
@@ -256,13 +256,15 @@ $phpthumbimg = '<img src="'.$phpthumb.'" alt="" />';
 $renderer['this.renderImage'] = "
     renderImage : function(val, md, rec, row, col, s){
         var source = s.pathconfigs[col];
-        if (val.substr(0,4) == 'http'){
-            return '{$httpimg}' ;
-		}        
-		if (val != ''){
-			return '{$phpthumbimg}';
+        if (val !== null) {
+	        if (val.substr(0,4) == 'http'){
+	            return '{$httpimg}' ;
+			}        
+			if (val != ''){
+				return '{$phpthumbimg}';
+			}
+			return val;
 		}
-		return val;
 	}
 ";
 


### PR DESCRIPTION
If the this.renderImage renderer is used and the db record for the image url is set to null the grid breaks completely and gets in a loading loop, only reloading the page helps and it just starts again =)...this fix checks if the passed value is null and if so does nothing.
