### PR TITLE
console.log() calls break IE9

### DIFF
--- a/core/components/migx/templates/mgr/grids/default.grid.tpl
+++ b/core/components/migx/templates/mgr/grids/default.grid.tpl
@@ -161,12 +161,12 @@ Ext.extend(MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal},MODx.grid.Grid,{
         /*
         if (this.windows[win_xtype]){
              //this.windows[win_xtype].destroy();
-             console.log(this.windows[win_xtype]);
+             //console.log(this.windows[win_xtype]);
              delete this.windows[win_xtype]; 
         }
         */
         
-        console.log('loadwin');
+        //console.log('loadwin');
         
 		this.loadWindow(btn,e,{
             xtype: win_xtype
@@ -197,7 +197,7 @@ Ext.extend(MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal},MODx.grid.Grid,{
         var items = tv ? tv.dom.value : '';
         var jsonvarkey = '{/literal}{$properties.jsonvarkey}{literal}';
         var action = action||'a';
-        console.log(co_id);
+        //console.log(co_id);
         if (action == 'a'){
            var object_id = 'new';
         }else{


### PR DESCRIPTION
commented out active console.log() calls bc they break the buttons in the grid in IE9
