### PR TITLE
Update migx.class.php

### DIFF
--- a/core/components/migx/model/migx/migx.class.php
+++ b/core/components/migx/model/migx/migx.class.php
@@ -1665,7 +1665,7 @@ class Migx {
                         break;
                     case 'find':
                     case 'find_in_set':
-                        $subject = explode(',', $subject);
+                        $subject = is_array($subject) ? $subject : explode(',', $subject);
                         $output = in_array($operand, $subject) ? $then : (isset($else) ? $else : '');
                         break;
                     case 'find_pd':


### PR DESCRIPTION
Makes it possible to use (array saved) listbox-multiple fields (defined in migx config, not with a native tv) together with find/find_in_set. The problem was, that it tried to split an already existing array by comma, which resulted in nothing instead of the array that was passed to the function for checking
