### PR TITLE
Add property for wrapperTpl

### DIFF
--- a/core/components/migx/elements/snippets/getimagelist.snippet.php
+++ b/core/components/migx/elements/snippets/getimagelist.snippet.php
@@ -37,6 +37,7 @@
 
 $tvname = $modx->getOption('tvname', $scriptProperties, '');
 $tpl = $modx->getOption('tpl', $scriptProperties, '');
+$wrapperTpl = $modx->getOption('wrapperTpl', $scriptProperties, '');
 $limit = $modx->getOption('limit', $scriptProperties, '0');
 $offset = $modx->getOption('offset', $scriptProperties, 0);
 $totalVar = $modx->getOption('totalVar', $scriptProperties, 'total');
@@ -389,6 +390,10 @@ if (is_array($output)) {
 if (!empty($toPlaceholder)) {
     $modx->setPlaceholder($toPlaceholder, $o);
     return '';
+}
+
+if (!empty($wrapperTpl)) {
+    $o = $modx->getChunk($wrapperTpl, 'output' => $o);
 }
 
 return $o;


### PR DESCRIPTION
Added functionality for a wrapper template chunk. This makes it easier to use getImageList in this situation:

[[
  [[*showList:is=`1`:then=`
    getImageList?
      &tpl=`teaser_kacheln_migx_tpl`
      &tvname=`teaser_kacheln`
`:else=`-`]]
]]

...with a wrapperTpl you can now add container markup etc easily.
