### PR TITLE
Detect Redactor Version

### DIFF
--- a/core/components/migx/elements/tv/input/migxredactor.class.php
+++ b/core/components/migx/elements/tv/input/migxredactor.class.php
@@ -55,6 +55,7 @@ class modTemplateVarInputRenderRedactor extends modTemplateVarInputRender {
         $this->setPlaceholder('assetsUrl', $redactor->config['assetsUrl']);
         $this->setPlaceholder('params', $params);
         $this->setPlaceholder('params_json', $this->modx->toJSON($params));
+        $this->setPlaceholder('redactorVersion',(is_null($redactor->version)) ? '1.4.3' : $version->float);
         //$this->registerStuff();
 
         //return parent::render($value, $params);

--- a/core/components/migx/elements/tv/redactor.tpl
+++ b/core/components/migx/elements/tv/redactor.tpl
@@ -1,4 +1,4 @@
-<script type="text/javascript" src="{$assetsUrl}redactor-1.3.4.min.js"></script>
+<script type="text/javascript" src="{$assetsUrl}redactor-{$redactorVersion}.min.js"></script>
 <textarea id="tv{$tv->id}" name="tv{$tv->id}" class="rtf-tinymcetv tv{$tv->id}" {literal}onchange="MODx.fireResourceFormChange();"{/literal}>{$tv->get('value')|escape}</textarea>
 
 <script type="text/javascript">


### PR DESCRIPTION
(untested)
Uses new `$redactor->version` API
https://www.modmore.com/extras/redactor/documentation/custom-component-u
sage/#jump_version_detection
Closes Bruno17/MIGX#161

While it would be best to factor MIGX to load the RTE the traditional
way (rather than hardcoding redactor editor.tpl) this PR should at
least ensure redactor support doesn’t break when users update redactor.

Note: Requires redactor 1.5.0 which is in the final stages of prepping
for release
