### PR TITLE
Putting offset before count condition

### DIFF
--- a/core/components/migx/elements/snippets/getimagelist.snippet.php
+++ b/core/components/migx/elements/snippets/getimagelist.snippet.php
@@ -161,10 +161,10 @@ if (is_array($sort) && count($sort) > 0) {
 
 $summaries = array();
 $output = '';
+$items = $offset > 0 ? array_slice($items, $offset) : $items;
 $count = count($items);
 
 if ($count > 0) {
-    $items = $offset > 0 ? array_slice($items, $offset) : $items;
 
     $limit = $limit == 0 || $limit > $count ? $count : $limit;
     $preselectLimit = $preselectLimit > $count ? $count : $preselectLimit;


### PR DESCRIPTION
Putting offset operation before count condition help fix problems with zero count of items, then offset is bigger then count of items.