### PR TITLE
Set seleted TV media source for default

### DIFF
--- a/core/components/migx/model/migx/migx.class.php
+++ b/core/components/migx/model/migx/migx.class.php
@@ -1438,8 +1438,11 @@ class Migx {
                 return $mediasource;
             }
         }
-
-        if ($this->source && $sourcefrom == 'migx') {
+        
+        $tv_id = $tv->get('id');// if empty, then no TV was passed
+        // If no TV then use default Media Source for the current MIGX TV: 
+        // Else (it has been assumed) a TV has been assigned/passed 
+        if ($this->source && ( $sourcefrom == 'migx' || empty($tv_id) ) {
             //use global MIGX-mediasource for all TVs
             $tv->setSource($this->source);
             $mediasource = $this->source;


### PR DESCRIPTION
Set the selected media source on the TV without any extra JSON code. This will make the code below usable on a single MIGX TV:

{"field":"image","caption":"Image","inputTVtype":"image"}

Related to #124 and #70

Thanks for MIGX and reviewing!