### PR TITLE
Update migxresourcemediapath.snippet.php

### DIFF
--- a/core/components/migx/elements/snippets/migxresourcemediapath.snippet.php
+++ b/core/components/migx/elements/snippets/migxresourcemediapath.snippet.php
@@ -104,7 +104,7 @@ if ($resource = $modx->getObject('modResource', $docid)) {
     $fullpath = $modx->getOption('base_path') . $path;
     
     if ($createpath && !file_exists($fullpath)) {
-        $permissions = $modx->getOption('new_folder_permissions', null, '0755', true);
+        $permissions = octdec($modx->getOption('new_folder_permissions', null, '0755', true));
         if (!@mkdir($fullpath, $permissions, true)) {
             $modx->log(MODX_LOG_LEVEL_ERROR, sprintf('[migxResourceMediaPath]: could not create directory %s).', $fullpath));
 


### PR DESCRIPTION
There are some strange behavior, when I create a folder via the "Media manager", then the folder is created with the rights of 0755, but if it is created automatically by "migxResourceMediaPath", then it gets the right 0341.Code is taken from "/processors/system/filesys/folder/create.php:20"

 After this change all was well