### PR TITLE
Fix and simplify Redactor implementation to use MODx.loadRTE()

### DIFF
--- a/core/components/migx/elements/tv/input/migxredactor.class.php
+++ b/core/components/migx/elements/tv/input/migxredactor.class.php
@@ -5,93 +5,10 @@
  */
 class modTemplateVarInputRenderRedactor extends modTemplateVarInputRender {
     public function process($value,array $params = array()) {
-        
-        $inputTVid = $this->modx->getOption('inputTVid',$params,0);
-        $which_editor = $this->modx->getOption('which_editor',null,'');
-        $this->setPlaceholder('which_editor',$which_editor);
-        
-        // Get Redactor class
-        $corePath = $this->modx->getOption('redactor.core_path', null, $this->modx->getOption('core_path').'components/redactor/');
-        $redactor = $this->modx->getService('redactor', 'Redactor', $corePath . 'model/redactor/');
-        if (!($redactor instanceof Redactor)) {
-            $this->modx->log(modX::LOG_LEVEL_ERROR, '[Redactor/MIGX] Error loading Redactor for use in MIGX from ' . $corePath);
-            return;
-        }
-        if ($this->modx->resource instanceof modResource) {
-            $redactor->setResource($this->modx->resource);
-        }
-        elseif (isset($_REQUEST['resource_id'])) {
-            $redactor->setResource($_REQUEST['resource_id']);
-        }
-
-        if (!empty($params['buttons']) && !is_array($params['buttons'])  ){
-            $params['buttons'] = explode(',',$params['buttons']);
-        }
-
-        /**
-         * Get the Redactor configuration on system level, and cleverly merge it with
-         * the TV configuration for inheritance and default values.
-         */
-        $systemOptions = $redactor->getGlobalOptions();
-        foreach ($params as $key => $value) {
-            if (($value == 'inherit' || $value == '') && isset($systemOptions[$key])) {
-                $params[$key] = $systemOptions[$key];
-            } 
-
-            $systemValue = (isset($systemOptions[$key])) ? $systemOptions[$key] : null;
-            $params[$key] = $this->_fixValueType($params[$key], $systemValue);
-        }
-        $params = array_merge($systemOptions, $params);
-        $params['imageGetJson'] = $params['imageGetJson'].'&tv=' . $inputTVid;
-        $params['fileGetJson'] = $params['fileGetJson'].'&tv=' . $inputTVid;
-        $params['imageUpload'] = $params['imageUpload'].'&tv=' . $inputTVid;
-        if(isset($params['clipboardUploadUrl'])) $params['clipboardUploadUrl'] = $params['clipboardUploadUrl'].'&tv=' . $inputTVid;
-        $params['fileUpload'] = $params['fileUpload'].'&tv=' . $inputTVid;
-        $params['plugins'] = array(); // wipe it clean and readd
-        if(isset($params['buttonFullScreen'])) $params['plugins'][] = "fullscreen";
-		if(isset($params['clipsJson']) && !empty($params['clipsJson'])) $params['plugins'][] = "clips";
-		if(isset($params['stylesJson']) && !empty($params['stylesJson'])) $params['plugins'][] = "styles";
-        /**
-         * Set placeholders and register CSS/JS files.
-         */
-        if (!empty($params['lang']) && ($params['lang'] != 'en')) {
-            $this->setPlaceholder('langFile', '<script type="text/javascript" src="' . $redactor->config['assetsUrl'] . 'lang/' . $params['lang'] . '.js"></script>');
-        }
-
-        $this->setPlaceholder('assetsUrl', $redactor->config['assetsUrl']);
-        $this->setPlaceholder('params', $params);
-        $this->setPlaceholder('params_json', $this->modx->toJSON($params));
-        $this->setPlaceholder('redactorVersion',(is_null($redactor->version)) ? '1.4.3' : $redactor->version->float);
-        //$this->registerStuff();
-
-        //return parent::render($value, $params);
     }
     public function getTemplate() {
         $corePath = $this->modx->getOption('migx.core_path', null, $this->modx->getOption('core_path') . 'components/migx/');
         return $corePath . 'elements/tv/redactor.tpl';  
     }
-    
-    /**
-     * Makes sure boolean values are boolean, and that array values are exploded properly.
-     *
-     * @param $value
-     * @param $systemValue
-     *
-     * @return array|bool
-     */
-    protected function _fixValueType($value, $systemValue) {
-        switch (gettype($systemValue)) {
-            case 'boolean':
-                $value = (bool)$value;
-                break;
-            case 'array':
-                if (!is_array($value)) {
-                    $value = $this->redactor->explode($value);
-                }
-                break;
-        }
-        return $value;
-    }    
-    
 }
 return 'modTemplateVarInputRenderRedactor';

--- a/core/components/migx/elements/tv/redactor.tpl
+++ b/core/components/migx/elements/tv/redactor.tpl
@@ -1,4 +1,3 @@
-<script type="text/javascript" src="{$assetsUrl}redactor-{$redactorVersion}.min.js"></script>
 <textarea id="tv{$tv->id}" name="tv{$tv->id}" class="rtf-tinymcetv tv{$tv->id}" {literal}onchange="MODx.fireResourceFormChange();"{/literal}>{$tv->get('value')|escape}</textarea>
 
 <script type="text/javascript">
@@ -10,16 +9,13 @@ Ext.onReady(function() {
     var tvid = 'tv{$tv->id}';
     var field = (Ext.get('tv{$tv->id}'));
     
-    
     {literal}
     field.onLoad = function(){
-        var $redTv = $redTv || ((typeof($red) != 'undefined') ? $red : $.noConflict());
-        $redTv(document).ready(function($) {
-          {/literal}
-          var tv{$tv->id}Options = {$params_json};
-          $('#tv{$tv->id}').redactor(tv{$tv->id}Options);
-          {literal}
-        });        
+        if (MODx.loadRTE) {
+            MODx.loadRTE(tvid);
+        } else if (window.console) {
+            console.error('Unable to instantiate editor to #' + tvid + ' - MODx.loadRTE is not defined');
+        }
     };
 
     // We don't need any specific handling for onHide or onBeforeSubmit.


### PR DESCRIPTION
Fixes #142 and modmore/Redactor#361 (private)

Previously the implementation of Redactor contained version specific code in the redactor.tpl, which becomes a problem when Redactor is updated and new features don't work in MIGX.

In this new situation, redactor.tpl simply calls the MODx.loadRTE method which is created by the relevant rich text editor when it is loaded on the manager page (rather than the connector, which doesn't work as script urls don't seem to get loaded).

This way, there is no need for code duplication or editor/version specific code in MIGX.