### PR TITLE
fix parsing chunks in tv

### DIFF
--- a/core/components/migx/model/migx/migxinputrender.class.php
+++ b/core/components/migx/model/migx/migxinputrender.class.php
@@ -80,6 +80,7 @@ class migxInputRender extends modTemplateVarInputRender {
         if (empty($columns)) {
             $columns = $this->modx->fromJSON($this->modx->getOption('columns', $properties, $default_columns));
             $columns = empty($properties['columns']) ? $this->modx->fromJSON($default_columns) : $columns;
+	    $this->migx->customconfigs['columns'] = $columns;
         }
 
         $this->migx->loadLang();


### PR DESCRIPTION
This fix for correctly parsing chunk when MIGX is use only in TV with type == "migx" without custom configuration, for example:

"renderchunktpl": "[[+field:striptags:strip:ellipsis=`100`]]"

or using chunk name:
"renderoptions": "[{\"name\":\"some_chunk_name\"}]",

