### PR TITLE
Update migx.tpl to constrain to the window area

### DIFF
--- a/core/components/migx/elements/tv/migx.tpl
+++ b/core/components/migx/elements/tv/migx.tpl
@@ -25,6 +25,7 @@ MODx.window.UpdateTvItem = function(config) {
         ,maximizable: true
         ,allowDrop: true
         ,height: '600'
+        ,constrain: true
         //,saveBtnText: _('done')
         ,forceLayout: true
         ,boxMaxHeight: '700'


### PR DESCRIPTION
Prevent the window from moving outside of browser area by adding "constrain: true".  Fixes issue addressed in #45
