### PR TITLE
Adding check for null on renderers

### DIFF
--- a/core/components/migx/configs/grid/grid.renderer.inc.php
+++ b/core/components/migx/configs/grid/grid.renderer.inc.php
@@ -83,6 +83,7 @@ renderCrossTick : function(val, md, rec, row, col, s) {
         case 0:
         case '0':
         case '':
+        case null:
         case false:
             renderImage = '/assets/components/migx/style/images/cross.png';
             handler = 'this.publishObject';
@@ -110,6 +111,7 @@ renderClickCrossTick : function(val, md, rec, row, col, s) {
         case 0:
         case '0':
         case '':
+        case null:
         case false:
             renderImage = '/assets/components/migx/style/images/cross.png';
             handler = 'this.publishObject';


### PR DESCRIPTION
renderClickCrossTick and renderCrossTick show a broken image if the field is null. Added two case null statements to cover this eventuality