### PR TITLE
Fix imageupload on PHP7 due to stray break statement

### DIFF
--- a/core/components/migx/model/imageupload/imageupload.php
+++ b/core/components/migx/model/imageupload/imageupload.php
@@ -194,7 +194,6 @@ if ($ajaxId || $ajaxUrl) {
     $output = str_replace('[+files+]', implode("\r\n", $fileList), $output);
     $output = str_replace('[+uid+]', $formUid, $output);
     return $output;
-    break;
 } else {
     return;
 }


### PR DESCRIPTION
This break statement was causing the following PHP error on PHP7:

> PHP Fatal error:  'break' not in the 'loop' or 'switch' context in core/components/migx/model/imageupload/imageupload.php on line 197

I suspect PHP7, or perhaps some sort of opcache, does more syntax checking before executing a file than PHP5, causing the break statement to trip it up. As it's an unreachable statement following the return it should not have any side effects. 

This appears to be the cause for #304 though that also mentions another issue with media source paths that I haven't identified yet.