### PR TITLE
Fix getImageList to allow TV to be attached to the Template and MIGX TV

### DIFF
--- a/core/components/migx/elements/snippets/getimagelist.snippet.php
+++ b/core/components/migx/elements/snippets/getimagelist.snippet.php
@@ -267,7 +267,27 @@ if ($count > 0) {
                 //don't manipulate any urls here
                 $modx->setOption('manipulatable_url_tv_output_types', '');
                 $tv->set('default_text', $value);
-                $value = $tv->renderOutput($docid);
+
+                // $value = $tv->renderOutput($docid); breaks if the TV used in MIGX is also assigned to this Template,
+                // example tv: imageLogo is assigned to the template and imageLogo is assigned to the MIGX TV as a result
+                // only the value of the imageLogo is returned for the MIGX TV instance
+                // need to override default MODX method: $value = $tv->renderOutput($docid);
+                /* process any TV commands in value */
+                $tv_value = $tv->processBindings($value, $docid);
+
+                $params = $tv->get('output_properties');
+                if (empty($params) || $params === null) {
+                    $params = [];
+                }
+
+                /* run prepareOutput to allow for custom overriding */
+                $tv_value = $tv->prepareOutput($tv_value, $docid);
+
+                /* find the render */
+                $outputRenderPaths = $tv->getRenderDirectories('OnTVOutputRenderList','output');
+                $value = $tv->getRender($params, $tv_value, $outputRenderPaths, 'output', $docid, $tv->get('display'));
+                // End override of $value = $tv->renderOutput($docid);
+
                 //set option back
                 $modx->setOption('manipulatable_url_tv_output_types', $mTypes);
                 //now manipulate urls


### PR DESCRIPTION
Fix for getImageList to allow a TV to be attached to the Template and used in a MIGX TV on the same template.

Current issue in getImageList snippet will set the same value in the MIGX TV output to the value of the TV that is directly attached to the Template. The data is saved correctly in the database with different values but the render methods always grab the attached TV value.

Example, create a TV like: imageLogo and then assign that TV to the the Base Template. Now create an MIGX TV and set imageLogo as one of the input TVs and attach to the Base Template. Now add the related MODX template tags to the Base Template and then fill in some data for those TVs. When you now view the resource it will only output the value of the root imageLogo TV value.

The offending code:
```php
$value = $tv->renderOutput($docid); 
```
The MODX [modTemplateVar->renderOutput](https://github.com/modxcms/revolution/blob/2.x/core/model/modx/modtemplatevar.class.php#L248) method will set the value to that of the passed resource ID related TV if directly attached, regardless of the value passed from MIGX.

Quick fix is then to replace the said code with code to override the renderOutput method by putting the related logic/code into the getImageList snippet like so:

```php
$tv_value = $tv->processBindings($value, $docid);

$params = $tv->get('output_properties');
if (empty($params) || $params === null) {
    $params = [];
}

/* run prepareOutput to allow for custom overriding */
$tv_value = $tv->prepareOutput($tv_value, $docid);

/* find the render */
$outputRenderPaths = $tv->getRenderDirectories('OnTVOutputRenderList','output');
$value = $tv->getRender($params, $tv_value, $outputRenderPaths, 'output', $docid, $tv->get('display'));
// End override of $value = $tv->renderOutput($docid);
```

