### PR TITLE
Fix the export if a join setting exist

### DIFF
--- a/core/components/migx/processors/mgr/default/export.php
+++ b/core/components/migx/processors/mgr/default/export.php
@@ -129,10 +129,6 @@ if (!isset($scriptProperties['download']) || !($scriptProperties['download'])) {
         $modx->migx->prepareJoins($classname, $joins, $c);
     }
 
-    if ($joins) {
-        $modx->migx->prepareJoins($classname, $joins, $c);
-    }
-
     if (isset($config['gridfilters']) && count($config['gridfilters']) > 0) {
         foreach ($config['gridfilters'] as $filter) {
 


### PR DESCRIPTION
At the moment the join is inserted double, which causes
```
[2019-05-06 15:04:07] (ERROR @ /.../core/xpdo/om/xpdoobject.class.php : 240) Error 42000 executing statement: 
Array
(
    [0] => 42000
    [1] => 1066
    [2] => Not unique table/alias: '...'
)
```