### PR TITLE
Fix transparency in .png

### DIFF
--- a/core/components/migx/configs/grid/grid.renderer.inc.php
+++ b/core/components/migx/configs/grid/grid.renderer.inc.php
@@ -4,7 +4,7 @@ $ctx = '{$ctx}';
 $val = "' + val + '";
 $httpimg = '<img style="height:60px" src="'.$val.'"/>';
 
-$phpthumb = "'+MODx.config.connectors_url+'system/phpthumb.php?w=80&h=80&f=png&ra=1&src='+val+source+'";
+$phpthumb = "'+MODx.config.connectors_url+'system/phpthumb.php?w=80&h=80&f=png&src='+val+source+'";
 $phpthumbimg = '<img src="'.$phpthumb.'" alt="" />';
 
 $assets_url = $this->modx->getOption('assets_url');
@@ -24,7 +24,7 @@ $renderer['this.renderImage'] = "
     }
 ";
 
-$phpthumb = "'+MODx.config.connectors_url+'system/phpthumb.php?w=80&h=80&f=png&ra=1&src='+val+'";
+$phpthumb = "'+MODx.config.connectors_url+'system/phpthumb.php?w=80&h=80&f=png&src='+val+'";
 $phpthumbimg = '<img src="'.$phpthumb.'" alt="" />';
 
 $renderer['this.renderImageFromHtml'] = "

--- a/core/components/migx/configs/grid/grid.renderer.inc.php
+++ b/core/components/migx/configs/grid/grid.renderer.inc.php
@@ -4,7 +4,7 @@ $ctx = '{$ctx}';
 $val = "' + val + '";
 $httpimg = '<img style="height:60px" src="'.$val.'"/>';
 
-$phpthumb = "'+MODx.config.connectors_url+'system/phpthumb.php?w=100&h=100&f=png&ra=1&src='+val+source+'";
+$phpthumb = "'+MODx.config.connectors_url+'system/phpthumb.php?w=80&h=80&f=png&ra=1&src='+val+source+'";
 $phpthumbimg = '<img src="'.$phpthumb.'" alt="" />';
 
 $assets_url = $this->modx->getOption('assets_url');
@@ -24,7 +24,7 @@ $renderer['this.renderImage'] = "
     }
 ";
 
-$phpthumb = "'+MODx.config.connectors_url+'system/phpthumb.php?w=100&h=100&f=png&ra=1&src='+val+'";
+$phpthumb = "'+MODx.config.connectors_url+'system/phpthumb.php?w=80&h=80&f=png&ra=1&src='+val+'";
 $phpthumbimg = '<img src="'.$phpthumb.'" alt="" />';
 
 $renderer['this.renderImageFromHtml'] = "

--- a/core/components/migx/configs/grid/grid.renderer.inc.php
+++ b/core/components/migx/configs/grid/grid.renderer.inc.php
@@ -4,7 +4,7 @@ $ctx = '{$ctx}';
 $val = "' + val + '";
 $httpimg = '<img style="height:60px" src="'.$val.'"/>';
 
-$phpthumb = "'+MODx.config.connectors_url+'system/phpthumb.php?h=60&src='+val+source+'";
+$phpthumb = "'+MODx.config.connectors_url+'system/phpthumb.php?w=100&h=100&f=png&ra=1&src='+val+source+'";
 $phpthumbimg = '<img src="'.$phpthumb.'" alt="" />';
 
 $assets_url = $this->modx->getOption('assets_url');
@@ -15,16 +15,16 @@ $renderer['this.renderImage'] = "
         if (val !== null) {
             if (val.substr(0,4) == 'http'){
                 return '{$httpimg}' ;
-            }        
+            }
             if (val != ''){
                 return '{$phpthumbimg}';
             }
             return val;
         }
-	}
+    }
 ";
 
-$phpthumb = "'+MODx.config.connectors_url+'system/phpthumb.php?h=60&src='+val+'";
+$phpthumb = "'+MODx.config.connectors_url+'system/phpthumb.php?w=100&h=100&f=png&ra=1&src='+val+'";
 $phpthumbimg = '<img src="'.$phpthumb.'" alt="" />';
 
 $renderer['this.renderImageFromHtml'] = "
@@ -33,18 +33,17 @@ $renderer['this.renderImageFromHtml'] = "
         if (val !== null) {
             if (val != ''){
                 var el = document.createElement('div');
-                el.innerHTML = val;               
+                el.innerHTML = val;
                 var img = el.querySelector('img');
-                
+
                 if (img){
                     val = img.getAttribute('src');
                     return '{$phpthumbimg}';
                 }
-                
             }
             return val;
         }
-	}
+    }
 
 ";
 
@@ -53,34 +52,33 @@ $renderer['this.renderImageFromHtml'] = "
 
 $renderer['this.renderPlaceholder'] = "
 renderPlaceholder : function(val, md, rec, row, col, s){
-         return '[[+'+val+'.'+rec.json.MIGX_id+']]';
-        
-	}
+        return '[[+'+val+'.'+rec.json.MIGX_id+']]';
+    }
 ";
 
 $renderer['this.renderFirst'] = "
 renderFirst : function(val, md, rec, row, col, s){
-		val = val.split(':');
+        val = val.split(':');
         return val[0];
-	}        
+    }
 ";
 
 $renderer['this.renderLimited'] = "
 renderLimited : function(val, md, rec, row, col, s){
-		var max = 100;
+        var max = 100;
         var count = val.length;
-		if (count>max){
+        if (count>max){
             return(val.substring(0, max));
-		}        
-		return val;
-	}    
+        }
+        return val;
+    }
 ";
 
 $img = '<img src="{0}" alt="{1}" title="{2}">';
 $renderer['this.renderCrossTick'] = "
 renderCrossTick : function(val, md, rec, row, col, s) {
     var renderImage, altText, handler, classname;
-    
+
     switch (val) {
         case 0:
         case '0':
@@ -152,7 +150,7 @@ renderSwitchStatusOptions : function(val, md, rec, row, col, s) {
 ";
 
 $tpl = '{6} <a href="#" ><img class="controlBtn btn_selectpos {4} selectpos" src="'.$base_url.$assets_url.'components/migx/style/images/arrow_updown.png" alt="select" title="select position"></a>';
-$tpl_active = '{6} '; 
+$tpl_active = '{6} ';
 $tpl_active .= '<a href="#" ><img class="controlBtn btn_before {4} {5}:before" src="'.$base_url.$assets_url.'components/migx/style/images/arrow_up.png" alt="before" title="move before"></a>';
 $tpl_active .= '<a href="#" ><img class="controlBtn btn_cancel {4} cancel" src="'.$base_url.$assets_url.'components/migx/style/images/cancel.png" alt="cancel" title="cancel"></a>';
 $tpl_active .= '<a href="#" ><img class="controlBtn btn_after {4} {5}:after" src="'.$base_url.$assets_url.'components/migx/style/images/arrow_down.png" alt="after" title="move after"></a>';
@@ -169,10 +167,10 @@ renderPositionSelector : function(val, md, rec, row, col, s) {
     }
     value = val;
     classname = 'test';
-    
+
     if (this.isPosSelecting){
         altText = 'before' ;
-        return String.format('{$tpl_active}', renderImage, altText, altText, classname, handler, column.dataIndex, value);            
+        return String.format('{$tpl_active}', renderImage, altText, altText, classname, handler, column.dataIndex, value);
     }
     else{
         altText = 'select' ;
@@ -183,9 +181,9 @@ renderPositionSelector : function(val, md, rec, row, col, s) {
 ";
 
 $renderer['this.renderRowActions'] = "
-	dummy:function(v,md,rec) {
+    dummy:function(v,md,rec) {
         // this function is fixed in the grid
-	} 
+    }
 ";
 
 $renderer['this.renderChunk'] = "
@@ -196,26 +194,25 @@ renderChunk : function(val, md, rec, row, col, s) {
 ";
 
 $renderer['ImagePlus.MIGX_Renderer'] = "
-	dummyImagePlus:function(v,md,rec) {
+    dummyImagePlus:function(v,md,rec) {
         // this function is included with the ImagePlus - TV
-	} 
+    }
 ";
 
 $renderer['this.renderDate'] = "
 renderDate : function(val, md, rec, row, col, s) {
     var date;
-	if (val && val != '') {
+    if (val && val != '') {
         if (typeof val == 'number') {
             date = new Date(val*1000);
         } else {
-			date = Date.parseDate(val, 'Y-m-d H:i:s');
+            date = Date.parseDate(val, 'Y-m-d H:i:s');
         }
         if (typeof(date) != 'undefined' ){
-		    return String.format('{0}', date.format(MODx.config.manager_date_format+' '+MODx.config.manager_time_format));
-        }    
-	} 
-	return '';
-	
+            return String.format('{0}', date.format(MODx.config.manager_date_format+' '+MODx.config.manager_time_format));
+        }
+    }
+    return '';
 }
 ";
 

--- a/core/components/migx/elements/tv/grids/default.grid.tpl
+++ b/core/components/migx/elements/tv/grids/default.grid.tpl
@@ -95,9 +95,9 @@ Ext.extend(MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal},MODx.grid.Grid,{
             return '<img style="height:60px" src="' + val + '"/>' ;
         }
         if (val != ''){
-            //return '<img src="{/literal}{$_config.connectors_url}{literal}system/phpthumb.php?w=100&h=100&f=png&ra=1&src=' + val + '" alt="" />';
+            //return '<img src="{/literal}{$_config.connectors_url}{literal}system/phpthumb.php?w=80&h=80&f=png&ra=1&src=' + val + '" alt="" />';
 
-            return '<img src="'+MODx.config.connectors_url+'{/literal}system/phpthumb.php?w=100&h=100&f=png&ra=1&src='+val+'&wctx={$ctx}'+source+'{literal}" alt="" />';
+            return '<img src="'+MODx.config.connectors_url+'{/literal}system/phpthumb.php?w=80&h=80&f=png&ra=1&src='+val+'&wctx={$ctx}'+source+'{literal}" alt="" />';
         }
         return val;
     }

--- a/core/components/migx/elements/tv/grids/default.grid.tpl
+++ b/core/components/migx/elements/tv/grids/default.grid.tpl
@@ -95,9 +95,9 @@ Ext.extend(MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal},MODx.grid.Grid,{
             return '<img style="height:60px" src="' + val + '"/>' ;
         }
         if (val != ''){
-            //return '<img src="{/literal}{$_config.connectors_url}{literal}system/phpthumb.php?w=80&h=80&f=png&ra=1&src=' + val + '" alt="" />';
+            //return '<img src="{/literal}{$_config.connectors_url}{literal}system/phpthumb.php?w=80&h=80&f=png&src=' + val + '" alt="" />';
 
-            return '<img src="'+MODx.config.connectors_url+'{/literal}system/phpthumb.php?w=80&h=80&f=png&ra=1&src='+val+'&wctx={$ctx}'+source+'{literal}" alt="" />';
+            return '<img src="'+MODx.config.connectors_url+'{/literal}system/phpthumb.php?w=80&h=80&f=png&src='+val+'&wctx={$ctx}'+source+'{literal}" alt="" />';
         }
         return val;
     }

--- a/core/components/migx/elements/tv/grids/default.grid.tpl
+++ b/core/components/migx/elements/tv/grids/default.grid.tpl
@@ -2,49 +2,49 @@
 
 MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal} = function(config) {
     config = config || {};
-	//console.log(config);
+    //console.log(config);
     this.sm = new Ext.grid.CheckboxSelectionModel();
 
     // define grid columns in a separate variable
     var cols=[this.sm];
-	for(i = 0; i <  config.columns.length; i++) {
- 		cols.push(config.columns[i]);
-    } 
-    config.columns=cols;    
+    for(i = 0; i <  config.columns.length; i++) {
+         cols.push(config.columns[i]);
+    }
+    config.columns=cols;
     Ext.applyIf(config,{
-	autoHeight: true,
+    autoHeight: true,
     collapsible: true,
-	resizable: true,
+    resizable: true,
     loadMask: true,
     paging: true,
     autosave: false,
     remoteSort: true,
     primaryKey: 'id',
-    isModified : false,    
+    isModified : false,
     sm: this.sm,
-	viewConfig: {
+    viewConfig: {
         emptyText: 'No items found',
         forceFit: true,
-		autoFill: true
+        autoFill: true
     },
     url : config.url,
-    baseParams: { 
+    baseParams: {
         action: 'mgr/migxdb/getList',
         configs: config.configs,
         resource_id: config.resource_id,
         object_id: config.object_id,
         'HTTP_MODAUTH': config.auth
     },
-    fields: ['id','pagetitle','createdon','published','deleted'],    
+    fields: ['id','pagetitle','createdon','published','deleted'],
     columns: [], // define grid columns in a separate variable
     tbar: [{
             text: '{/literal}{$i18n.mig_add}{literal}',
-			handler: this.addItem
+            handler: this.addItem
         }
         {/literal}{if $properties.previewurl != ''}{literal}
         ,{
             text: '{/literal}{$i18n.mig_preview}{literal}',
-			handler: this.preview
+            handler: this.preview
         }
         {/literal}{/if}{literal}
         ,{
@@ -55,21 +55,21 @@ MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal} = function(config) {
                 scale: 'large'
             },
             items: [{
-					text: 'Stapeloperationen',
-					menu: [{
-						text: 'markierte veröffentlichen',
-						handler: this.publishSelected,
-						scope: this
-					}, {
-						text: 'markierte zurückziehen',
-						handler: this.unpublishSelected,
-						scope: this
-					}, {
-						text: 'markierte löschen',
-						handler: this.deleteSelected,
-						scope: this
-					}]
-				},{
+                    text: 'Stapeloperationen',
+                    menu: [{
+                        text: 'markierte veröffentlichen',
+                        handler: this.publishSelected,
+                        scope: this
+                    }, {
+                        text: 'markierte zurückziehen',
+                        handler: this.unpublishSelected,
+                        scope: this
+                    }, {
+                        text: 'markierte löschen',
+                        handler: this.deleteSelected,
+                        scope: this
+                    }]
+                },{
                     text: ('{/literal}{$i18n.mig_show_trash}{literal}')
                     ,handler: this.toggleDeleted
                     ,enableToggle: true
@@ -77,63 +77,61 @@ MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal} = function(config) {
                 }
                 {/literal}{$customconfigs.gridactionbuttons}{literal}
                 ]
-    		}         
-        ]        
+            }
+        ]
     });
-	
+
     MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal}.superclass.constructor.call(this,config)
     this.getStore().pathconfigs=config.pathconfigs;
-	//this.loadData();
+    //this.loadData();
 };
 Ext.extend(MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal},MODx.grid.Grid,{
     _renderUrl: function(v,md,rec) {
         return '<a href="'+v+'" target="_blank">'+rec.data.pagetitle+'</a>';
     }
     ,renderImage : function(val, md, rec, row, col, s){
-		var source = s.pathconfigs[col];
-		if (val.substr(0,4) == 'http'){
-			return '<img style="height:60px" src="' + val + '"/>' ;
-		}        
-		if (val != ''){
-			//return '<img src="{/literal}{$_config.connectors_url}{literal}system/phpthumb.php?h=60&src=' + val + '" alt="" />';
-			
-			return '<img src="'+MODx.config.connectors_url+'{/literal}system/phpthumb.php?h=60&src='+val+'&wctx={$ctx}'+source+'{literal}" alt="" />';
-		
-		}
-		return val;
-	}
+        var source = s.pathconfigs[col];
+        if (val.substr(0,4) == 'http'){
+            return '<img style="height:60px" src="' + val + '"/>' ;
+        }
+        if (val != ''){
+            //return '<img src="{/literal}{$_config.connectors_url}{literal}system/phpthumb.php?w=100&h=100&f=png&ra=1&src=' + val + '" alt="" />';
+
+            return '<img src="'+MODx.config.connectors_url+'{/literal}system/phpthumb.php?w=100&h=100&f=png&ra=1&src='+val+'&wctx={$ctx}'+source+'{literal}" alt="" />';
+        }
+        return val;
+    }
     ,renderPlaceholder : function(val, md, rec, row, col, s){
         return '[[+'+val+'.'+rec.json.MIGX_id+']]';
-        
-	}
+    }
     {/literal}{$customconfigs.gridfunctions}{literal}
     ,renderFirst : function(val, md, rec, row, col, s){
-		val = val.split(':');
+        val = val.split(':');
         return val[0];
-        
+
         /*
         var max = 100;
         var count = val.length;
-		if (count>max){
+        if (count>max){
             return(val.substring(0, max));
-		}
-        */        
-		return val;
-	}        
+        }
+        */
+        return val;
+    }
     ,renderLimited : function(val, md, rec, row, col, s){
-		var max = 100;
+        var max = 100;
         var count = val.length;
-		if (count>max){
+        if (count>max){
             return(val.substring(0, max));
-		}        
-		return val;
-	}    
+        }
+        return val;
+    }
     ,renderPreview : function(val,md,rec){
-		return val;
-	}
+        return val;
+    }
 
-	,loadData: function(){
-	    var items_string = Ext.get('tv{/literal}{$tv->id}{literal}').dom.value;
+    ,loadData: function(){
+        var items_string = Ext.get('tv{/literal}{$tv->id}{literal}').dom.value;
         var items = [];
         var item = {};
         try {
@@ -141,25 +139,25 @@ Ext.extend(MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal},MODx.grid.Grid,{
         }
         catch (e){
         }
-                
+
         this.autoinc = 0;
         for(i = 0; i <  items.length; i++) {
- 		    item = items[i];
+             item = items[i];
             if (item.MIGX_id){
                 if (item.MIGX_id > this.autoinc){
                     this.autoinc = item.MIGX_id;
                 }
             }else{
                 item.MIGX_id = this.autoinc +1 ;
-                this.autoinc = item.MIGX_id;                 
-            }	
-           items[i] = item;  
-        } 
-        
-		this.getStore().sortInfo = null;
-		this.getStore().loadData(items);
-			
-		this.syncSize();
+                this.autoinc = item.MIGX_id;
+            }
+           items[i] = item;
+        }
+
+        this.getStore().sortInfo = null;
+        this.getStore().loadData(items);
+
+        this.syncSize();
         this.setWidth('100%');
     }
 
@@ -174,26 +172,26 @@ Ext.extend(MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal},MODx.grid.Grid,{
         cs = Ext.util.Format.substr(cs,1,cs.length-1);
         return cs;
     }
-	,addItem: function(btn,e) {
-		var s=this.getStore();
-		this.loadWin(btn,e,s.getCount(),'a');
-	}
-	,preview: function(btn,e) {
-		var s=this.getStore();
-		this.loadPreviewWin(btn,e,s.getCount(),'a');
-	}    	
-	,remove: function() {
+    ,addItem: function(btn,e) {
+        var s=this.getStore();
+        this.loadWin(btn,e,s.getCount(),'a');
+    }
+    ,preview: function(btn,e) {
+        var s=this.getStore();
+        this.loadPreviewWin(btn,e,s.getCount(),'a');
+    }
+    ,remove: function() {
         var _this=this;
-		Ext.Msg.confirm(_('warning') || '','{/literal}{$i18n.mig_remove_confirm}{literal}' || '',function(e) {
+        Ext.Msg.confirm(_('warning') || '','{/literal}{$i18n.mig_remove_confirm}{literal}' || '',function(e) {
             if (e == 'yes') {
-				_this.getStore().removeAt(_this.menu.recordIndex);
+                _this.getStore().removeAt(_this.menu.recordIndex);
                 _this.getView().refresh();
-		        _this.collectItems();
-                MODx.fireResourceFormChange();	
+                _this.collectItems();
+                MODx.fireResourceFormChange();
                 }
-            }),this;		
-	}   
-	,update: function(btn,e) {
+            }),this;
+    }
+    ,update: function(btn,e) {
       this.loadWin(btn,e,this.menu.recordIndex,'u');
     }
     ,toggleDeleted: function(btn,e) {
@@ -209,44 +207,44 @@ Ext.extend(MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal},MODx.grid.Grid,{
         s.removeAll();
         this.refresh();
     }
-	,publishObject: function() {
+    ,publishObject: function() {
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
                 action: 'mgr/migxdb/update'
-				,task: 'publish'
+                ,task: 'publish'
                 ,object_id: this.menu.record.id
-				,configs: this.config.configs
+                ,configs: this.config.configs
             }
             ,listeners: {
                 'success': {fn:this.refresh,scope:this}
             }
         });
-    }	
+    }
     ,unpublishObject: function() {
- 		MODx.Ajax.request({
+         MODx.Ajax.request({
             url: this.config.url
             ,params: {
                 action: 'mgr/migxdb/update'
-				,task: 'unpublish'
+                ,task: 'unpublish'
                 ,object_id: this.menu.record.id
-				,configs: this.config.configs
+                ,configs: this.config.configs
             }
             ,listeners: {
                 'success': {fn:this.refresh,scope:this}
             }
         });
-    }    
+    }
     ,publishSelected: function(btn,e) {
         var cs = this.getSelectedAsList();
         if (cs === false) return false;
-        
+
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
                 action: 'mgr/{/literal}{$customconfigs.task}{literal}/bulkupdate'
-				,configs: this.config.configs
-				,task: 'publish'
+                ,configs: this.config.configs
+                ,task: 'publish'
                 ,objects: cs
             }
             ,listeners: {
@@ -260,13 +258,13 @@ Ext.extend(MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal},MODx.grid.Grid,{
     },unpublishSelected: function(btn,e) {
         var cs = this.getSelectedAsList();
         if (cs === false) return false;
-        
+
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
                 action: 'mgr/{/literal}{$customconfigs.task}{literal}/bulkupdate'
-				,configs: this.config.configs
-				,task: 'unpublish'
+                ,configs: this.config.configs
+                ,task: 'unpublish'
                 ,objects: cs
             }
             ,listeners: {
@@ -280,13 +278,13 @@ Ext.extend(MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal},MODx.grid.Grid,{
     },deleteSelected: function(btn,e) {
         var cs = this.getSelectedAsList();
         if (cs === false) return false;
-        
+
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
                 action: 'mgr/{/literal}{$customconfigs.task}{literal}/bulkupdate'
-				,configs: this.config.configs
-				,task: 'delete'
+                ,configs: this.config.configs
+                ,task: 'delete'
                 ,objects: cs
             }
             ,listeners: {
@@ -302,9 +300,9 @@ Ext.extend(MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal},MODx.grid.Grid,{
             url: this.config.url
             ,params: {
                 action: 'mgr/migxdb/update'
-				,task: 'delete'
+                ,task: 'delete'
                 ,object_id: this.menu.record.id
-				,configs: this.config.configs
+                ,configs: this.config.configs
             }
             ,listeners: {
                 'success': {fn:this.refresh,scope:this}
@@ -315,9 +313,9 @@ Ext.extend(MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal},MODx.grid.Grid,{
             url: this.config.url
             ,params: {
                 action: 'mgr/migxdb/update'
-				,task: 'recall'
+                ,task: 'recall'
                 ,object_id: this.menu.record.id
-				,configs: this.config.configs
+                ,configs: this.config.configs
             }
             ,listeners: {
                 'success': {fn:this.refresh,scope:this}
@@ -328,17 +326,17 @@ Ext.extend(MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal},MODx.grid.Grid,{
             url: this.config.url
             ,params: {
                 action: 'mgr/{/literal}{$customconfigs.task}{literal}/remove'
-				,task: 'removeone'
+                ,task: 'removeone'
                 ,object_id: this.menu.record.id
-				,configs: this.config.configs
+                ,configs: this.config.configs
             }
             ,listeners: {
                 'success': {fn:this.refresh,scope:this}
             }
         });
-    }                	     
-	,loadWin: function(btn,e,index,action,tempParams) {
-	    var resource_id = '{/literal}{$resource.id}{literal}';
+    }
+    ,loadWin: function(btn,e,index,action,tempParams) {
+        var resource_id = '{/literal}{$resource.id}{literal}';
         var tempParams = tempParams || null;
         var co_id = '{/literal}{$connected_object_id}{literal}';
         {/literal}{if $properties.autoResourceFolders == 'true'}{literal}
@@ -346,55 +344,55 @@ Ext.extend(MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal},MODx.grid.Grid,{
             alert ('{/literal}{$i18n.mig_save_resource}{literal}');
             return;
         }
-        {/literal}{/if}{literal}        
-       
+        {/literal}{/if}{literal}
+
         if (action == 'a'){
            //var json='{/literal}{$newitem}{literal}';
            //var data=Ext.util.JSON.decode(json);
            var object_id = 'new';
         }else{
-		   //var s = this.getStore();
-           //var rec = s.getAt(index)            
+           //var s = this.getStore();
+           //var rec = s.getAt(index)
            //var data = rec.data;
            //console.log(data);
            //var json = Ext.util.JSON.encode(rec.json);
            var object_id = this.menu.record.id;
         }
-        
+
         var isnew = (action == 'u') ? '0':'1';
-        
- 		
+
+
         var win_xtype = 'modx-window-tv-dbitem-update-{/literal}{$win_id}{literal}';
-		if (this.windows[win_xtype]){
-			this.windows[win_xtype].fp.autoLoad.params.tv_id='{/literal}{$tv->id}{literal}';
-			this.windows[win_xtype].fp.autoLoad.params.resource_id=resource_id;
+        if (this.windows[win_xtype]){
+            this.windows[win_xtype].fp.autoLoad.params.tv_id='{/literal}{$tv->id}{literal}';
+            this.windows[win_xtype].fp.autoLoad.params.resource_id=resource_id;
             this.windows[win_xtype].fp.autoLoad.params.co_id=co_id;
             this.windows[win_xtype].fp.autoLoad.params.configs=this.config.configs;
             this.windows[win_xtype].fp.autoLoad.params.tv_name='{/literal}{$tv->name}{literal}';
-		    //this.windows[win_xtype].fp.autoLoad.params.itemid=index;
+            //this.windows[win_xtype].fp.autoLoad.params.itemid=index;
             //this.windows[win_xtype].fp.autoLoad.params.record_json=json;
             //this.windows[win_xtype].fp.autoLoad.params.autoinc=this.autoinc;
             //this.windows[win_xtype].fp.autoLoad.params.isnew=isnew;
             this.windows[win_xtype].fp.autoLoad.params.object_id=object_id;
             this.windows[win_xtype].fp.autoLoad.params.tempParams=tempParams;
-			this.windows[win_xtype].grid=this;
+            this.windows[win_xtype].grid=this;
             this.windows[win_xtype].action=action;
-           
-		}
-		this.loadWindow(btn,e,{
+
+        }
+        this.loadWindow(btn,e,{
             xtype: win_xtype
             //,record: data
-			,grid: this
+            ,grid: this
             ,action: action
-            
+
             ,baseParams : {
-				//record_json:json,
-			    action: 'mgr/migxdb/fields',
-				tv_id: '{/literal}{$tv->id}{literal}',
-				tv_name: '{/literal}{$tv->name}{literal}',
-				'class_key': 'modDocument',
+                //record_json:json,
+                action: 'mgr/migxdb/fields',
+                tv_id: '{/literal}{$tv->id}{literal}',
+                tv_name: '{/literal}{$tv->name}{literal}',
+                'class_key': 'modDocument',
                 'wctx':'{/literal}{$myctx}{literal}',
-				//itemid : index,
+                //itemid : index,
                 //autoinc : this.autoinc,
                 object_id: object_id,
                 configs: this.config.configs,
@@ -402,39 +400,39 @@ Ext.extend(MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal},MODx.grid.Grid,{
                 resource_id : resource_id,
                 co_id : co_id,
                 tempParams: tempParams
-			}
+            }
         });
     }
-	,loadPreviewWin: function(btn,e,index,action) {
+    ,loadPreviewWin: function(btn,e,index,action) {
         var items = Ext.get('tv{/literal}{$tv->id}{literal}').dom.value;
-		//console.log((items));
+        //console.log((items));
         var jsonvarkey = '{/literal}{$properties.jsonvarkey}{literal}';
         if (jsonvarkey == ''){
             jsonvarkey = 'migx_outputvalue';
         }
         var win_xtype = 'modx-window-mi-preview';
-		if (this.windows[win_xtype]){
-			//this.windows[win_xtype].fp.autoLoad.params.tv_id='{/literal}{$tv->id}{literal}';
-			//this.windows[win_xtype].fp.autoLoad.params.tv_name='{/literal}{$tv->name}{literal}';
-		    //this.windows[win_xtype].fp.autoLoad.params.itemid=index;
+        if (this.windows[win_xtype]){
+            //this.windows[win_xtype].fp.autoLoad.params.tv_id='{/literal}{$tv->id}{literal}';
+            //this.windows[win_xtype].fp.autoLoad.params.tv_name='{/literal}{$tv->name}{literal}';
+            //this.windows[win_xtype].fp.autoLoad.params.itemid=index;
             //this.windows[win_xtype].fp.autoLoad.params.record_json=json;
             this.windows[win_xtype].src='{/literal}{$properties.previewurl}{literal}';
-			this.windows[win_xtype].json=items;
+            this.windows[win_xtype].json=items;
             this.windows[win_xtype].jsonvarkey=jsonvarkey;
             this.windows[win_xtype].action=action;
-		}
-		this.loadWindow(btn,e,{
+        }
+        this.loadWindow(btn,e,{
             xtype: win_xtype
             ,src: '{/literal}{$properties.previewurl}{literal}'
             ,jsonvarkey:jsonvarkey
             ,json: items
-			,grid: this
+            ,grid: this
             ,action: action
         });
-    }    	
+    }
     ,getMenu: function() {
-		var n = this.menu.record;
-        //console.log(this.menu); 
+        var n = this.menu.record;
+        //console.log(this.menu);
         var m = [];
         m.push({
             text: '{/literal}{$i18n.mig_edit}{literal}'
@@ -451,42 +449,42 @@ Ext.extend(MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal},MODx.grid.Grid,{
                 text: 'zurückziehen'
                 ,handler: this.unpublishObject
             });
-        }        
+        }
         m.push('-');
         if (n.deleted == 1) {
         m.push({
             text: 'wiederherstellen'
             ,handler: this.recallObject
         });
-		m.push('-');
+        m.push('-');
         m.push({
             text: 'entfernen'
             ,handler: this.removeObject
-        });						
+        });
         } else if (n.deleted == 0) {
         m.push({
             text: 'löschen'
             ,handler: this.deleteObject
-        });		
+        });
         }
-        {/literal}{$customconfigs.gridcontextmenus}{literal}        	        
-		return m;
+        {/literal}{$customconfigs.gridcontextmenus}{literal}
+        return m;
     }
-	,collectItems: function(){
-		var items=[];
-		// read jsons from grid-store-items 
+    ,collectItems: function(){
+        var items=[];
+        // read jsons from grid-store-items
         var griddata=this.store.data;
-		for(i = 0; i <  griddata.length; i++) {
- 			items.push(griddata.items[i].json);
+        for(i = 0; i <  griddata.length; i++) {
+             items.push(griddata.items[i].json);
         }
         if (items.length >0){
-           Ext.get('tv{/literal}{$tv->id}{literal}').dom.value = Ext.util.JSON.encode(items); 
+           Ext.get('tv{/literal}{$tv->id}{literal}').dom.value = Ext.util.JSON.encode(items);
         }
         else{
-           Ext.get('tv{/literal}{$tv->id}{literal}').dom.value = '';  
+           Ext.get('tv{/literal}{$tv->id}{literal}').dom.value = '';
         }
-        
-		return;						 
+
+        return;
     }
 });
 Ext.reg('modx-grid-multitvdbgrid-{/literal}{$win_id}{literal}',MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal});

--- a/core/components/migx/elements/tv/grids/dragdrop.grid.tpl
+++ b/core/components/migx/elements/tv/grids/dragdrop.grid.tpl
@@ -151,9 +151,9 @@ Ext.extend(MODx.grid.multiTVdbgrid,MODx.grid.Grid,{
             return '<img style="height:60px" src="' + val + '"/>' ;
         }
         if (val != ''){
-            //return '<img src="{/literal}{$_config.connectors_url}{literal}system/phpthumb.php?w=100&h=100&f=png&ra=1&src=' + val + '" alt="" />';
+            //return '<img src="{/literal}{$_config.connectors_url}{literal}system/phpthumb.php?w=80&h=80&f=png&ra=1&src=' + val + '" alt="" />';
 
-            return '<img src="'+MODx.config.connectors_url+'{/literal}system/phpthumb.php?w=100&h=100&f=png&ra=1&src='+val+'&wctx={$ctx}'+source+'{literal}" alt="" />';
+            return '<img src="'+MODx.config.connectors_url+'{/literal}system/phpthumb.php?w=80&h=80&f=png&ra=1&src='+val+'&wctx={$ctx}'+source+'{literal}" alt="" />';
         }
         return val;
     }

--- a/core/components/migx/elements/tv/grids/dragdrop.grid.tpl
+++ b/core/components/migx/elements/tv/grids/dragdrop.grid.tpl
@@ -2,32 +2,32 @@
 
 MODx.grid.multiTVdbgrid = function(config) {
     config = config || {};
-	//console.log(config);
+    //console.log(config);
     this.sm = new Ext.grid.CheckboxSelectionModel();
 
     // define grid columns in a separate variable
     var cols=[this.sm];
-	for(i = 0; i <  config.columns.length; i++) {
- 		cols.push(config.columns[i]);
-    } 
-    config.columns=cols;    
+    for(i = 0; i <  config.columns.length; i++) {
+         cols.push(config.columns[i]);
+    }
+    config.columns=cols;
     Ext.applyIf(config,{
-	autoHeight: true,
+    autoHeight: true,
     collapsible: true,
-	resizable: true,
+    resizable: true,
     loadMask: true,
     paging: true,
     autosave: false,
     remoteSort: true,
     primaryKey: 'id',
     isModified : false,
-	ddGroup:'{/literal}{$tv->id}{literal}_gridDD',
-    enableDragDrop: true, // enable drag and drop of grid rows    
- 	viewConfig: {
+    ddGroup:'{/literal}{$tv->id}{literal}_gridDD',
+    enableDragDrop: true, // enable drag and drop of grid rows
+     viewConfig: {
         emptyText: 'No items found',
         sm: new Ext.grid.RowSelectionModel({singleSelect:true}),
         forceFit: true,
-		autoFill: true
+        autoFill: true
     },
     listeners: {
         "render": {
@@ -44,7 +44,7 @@ MODx.grid.multiTVdbgrid = function(config) {
                   notifyDrop : function(dd, e, data){
                       var ds = grid.store;
 
-					  alert('Hello world!'); 
+                      alert('Hello world!');
                       // NOTE:
                       // you may need to make an ajax call here
                       // to send the new order
@@ -64,44 +64,44 @@ MODx.grid.multiTVdbgrid = function(config) {
                                 for(i = 0; i <  rows.length; i++) {
                                 ds.remove(ds.getById(rows[i].id));
                                 }
-     							ds.insert(cindex,data.selections);
+                                 ds.insert(cindex,data.selections);
                                 sm.clearSelections();
                              }
                              MODx.fireResourceFormChange();
                          }
-						grid.collectItems();
+                        grid.collectItems();
                         grid.getView().refresh();
 
- 
+
                         // ************************************
                       }
-                   }) 
-		
-		this.setWidth('99%');
-		//this.syncSize();
+                   })
+
+        this.setWidth('99%');
+        //this.syncSize();
                    // load the grid store
                   //  after the grid has been rendered
                   //store.load();
        }
    }
-},	
+},
     url : config.url,
-    baseParams: { 
+    baseParams: {
         action: 'mgr/migxdb/getList',
         configs: config.configs,
         resource_id: config.resource_id,
         'HTTP_MODAUTH': config.auth
     },
-    fields: ['id','pagetitle','createdon','published','deleted'],    
+    fields: ['id','pagetitle','createdon','published','deleted'],
     columns: [], // define grid columns in a separate variable
     tbar: [{
             text: '{/literal}{$i18n.mig_add}{literal}',
-			handler: this.addItem
+            handler: this.addItem
         }
         {/literal}{if $properties.previewurl != ''}{literal}
         ,{
             text: '{/literal}{$i18n.mig_preview}{literal}',
-			handler: this.preview
+            handler: this.preview
         }
         {/literal}{/if}{literal}
         ,{
@@ -112,83 +112,81 @@ MODx.grid.multiTVdbgrid = function(config) {
                 scale: 'large'
             },
             items: [{
-					text: 'Stapeloperationen',
-					menu: [{
-						text: 'markierte veröffentlichen',
-						handler: this.publishSelected,
-						scope: this
-					}, {
-						text: 'markierte zurückziehen',
-						handler: this.unpublishSelected,
-						scope: this
-					}, {
-						text: 'markierte löschen',
-						handler: this.deleteSelected,
-						scope: this
-					}]
-				},{
+                    text: 'Stapeloperationen',
+                    menu: [{
+                        text: 'markierte verï¿½ffentlichen',
+                        handler: this.publishSelected,
+                        scope: this
+                    }, {
+                        text: 'markierte zurï¿½ckziehen',
+                        handler: this.unpublishSelected,
+                        scope: this
+                    }, {
+                        text: 'markierte lï¿½schen',
+                        handler: this.deleteSelected,
+                        scope: this
+                    }]
+                },{
                     text: ('{/literal}{$i18n.mig_show_trash}{literal}')
                     ,handler: this.toggleDeleted
                     ,enableToggle: true
                     ,scope: this
                 }]
-			
-			}         
-        ]        
+
+            }
+        ]
     });
-	
+
     MODx.grid.multiTVdbgrid.superclass.constructor.call(this,config)
     this.getStore().pathconfigs=config.pathconfigs;
-	//this.loadData();
+    //this.loadData();
 };
 Ext.extend(MODx.grid.multiTVdbgrid,MODx.grid.Grid,{
     _renderUrl: function(v,md,rec) {
         return '<a href="'+v+'" target="_blank">'+rec.data.pagetitle+'</a>';
     }
     ,renderImage : function(val, md, rec, row, col, s){
-		var source = s.pathconfigs[col];
-		if (val.substr(0,4) == 'http'){
-			return '<img style="height:60px" src="' + val + '"/>' ;
-		}        
-		if (val != ''){
-			//return '<img src="{/literal}{$_config.connectors_url}{literal}system/phpthumb.php?h=60&src=' + val + '" alt="" />';
-			
-			return '<img src="'+MODx.config.connectors_url+'{/literal}system/phpthumb.php?h=60&src='+val+'&wctx={$ctx}'+source+'{literal}" alt="" />';
-		
-		}
-		return val;
-	}
+        var source = s.pathconfigs[col];
+        if (val.substr(0,4) == 'http'){
+            return '<img style="height:60px" src="' + val + '"/>' ;
+        }
+        if (val != ''){
+            //return '<img src="{/literal}{$_config.connectors_url}{literal}system/phpthumb.php?w=100&h=100&f=png&ra=1&src=' + val + '" alt="" />';
+
+            return '<img src="'+MODx.config.connectors_url+'{/literal}system/phpthumb.php?w=100&h=100&f=png&ra=1&src='+val+'&wctx={$ctx}'+source+'{literal}" alt="" />';
+        }
+        return val;
+    }
     ,renderPlaceholder : function(val, md, rec, row, col, s){
         return '[[+'+val+'.'+rec.json.MIGX_id+']]';
-        
-	}       
+    }
     ,renderFirst : function(val, md, rec, row, col, s){
-		val = val.split(':');
+        val = val.split(':');
         return val[0];
-        
+
         /*
         var max = 100;
         var count = val.length;
-		if (count>max){
+        if (count>max){
             return(val.substring(0, max));
-		}
-        */        
-		return val;
-	}        
+        }
+        */
+        return val;
+    }
     ,renderLimited : function(val, md, rec, row, col, s){
-		var max = 100;
+        var max = 100;
         var count = val.length;
-		if (count>max){
+        if (count>max){
             return(val.substring(0, max));
-		}        
-		return val;
-	}    
+        }
+        return val;
+    }
     ,renderPreview : function(val,md,rec){
-		return val;
-	}
+        return val;
+    }
 
-	,loadData: function(){
-	    var items_string = Ext.get('tv{/literal}{$tv->id}{literal}').dom.value;
+    ,loadData: function(){
+        var items_string = Ext.get('tv{/literal}{$tv->id}{literal}').dom.value;
         var items = [];
         var item = {};
         try {
@@ -196,25 +194,25 @@ Ext.extend(MODx.grid.multiTVdbgrid,MODx.grid.Grid,{
         }
         catch (e){
         }
-                
+
         this.autoinc = 0;
         for(i = 0; i <  items.length; i++) {
- 		    item = items[i];
+             item = items[i];
             if (item.MIGX_id){
                 if (item.MIGX_id > this.autoinc){
                     this.autoinc = item.MIGX_id;
                 }
             }else{
                 item.MIGX_id = this.autoinc +1 ;
-                this.autoinc = item.MIGX_id;                 
-            }	
-           items[i] = item;  
-        } 
-        
-		this.getStore().sortInfo = null;
-		this.getStore().loadData(items);
-			
-		this.syncSize();
+                this.autoinc = item.MIGX_id;
+            }
+           items[i] = item;
+        }
+
+        this.getStore().sortInfo = null;
+        this.getStore().loadData(items);
+
+        this.syncSize();
         this.setWidth('100%');
     }
 
@@ -229,26 +227,26 @@ Ext.extend(MODx.grid.multiTVdbgrid,MODx.grid.Grid,{
         cs = Ext.util.Format.substr(cs,1,cs.length-1);
         return cs;
     }
-	,addItem: function(btn,e) {
-		var s=this.getStore();
-		this.loadWin(btn,e,s.getCount(),'a');
-	}
-	,preview: function(btn,e) {
-		var s=this.getStore();
-		this.loadPreviewWin(btn,e,s.getCount(),'a');
-	}    	
-	,remove: function() {
+    ,addItem: function(btn,e) {
+        var s=this.getStore();
+        this.loadWin(btn,e,s.getCount(),'a');
+    }
+    ,preview: function(btn,e) {
+        var s=this.getStore();
+        this.loadPreviewWin(btn,e,s.getCount(),'a');
+    }
+    ,remove: function() {
         var _this=this;
-		Ext.Msg.confirm(_('warning') || '','{/literal}{$i18n.mig_remove_confirm}{literal}' || '',function(e) {
+        Ext.Msg.confirm(_('warning') || '','{/literal}{$i18n.mig_remove_confirm}{literal}' || '',function(e) {
             if (e == 'yes') {
-				_this.getStore().removeAt(_this.menu.recordIndex);
+                _this.getStore().removeAt(_this.menu.recordIndex);
                 _this.getView().refresh();
-		        _this.collectItems();
-                MODx.fireResourceFormChange();	
+                _this.collectItems();
+                MODx.fireResourceFormChange();
                 }
-            }),this;		
-	}   
-	,update: function(btn,e) {
+            }),this;
+    }
+    ,update: function(btn,e) {
       this.loadWin(btn,e,this.menu.recordIndex,'u');
     }
     ,toggleDeleted: function(btn,e) {
@@ -267,13 +265,13 @@ Ext.extend(MODx.grid.multiTVdbgrid,MODx.grid.Grid,{
     ,publishSelected: function(btn,e) {
         var cs = this.getSelectedAsList();
         if (cs === false) return false;
-        
+
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
                 action: 'mgr/{/literal}{$customconfigs.task}{literal}/bulkupdate'
-				,configs: this.config.configs
-				,task: 'publish'
+                ,configs: this.config.configs
+                ,task: 'publish'
                 ,objects: cs
             }
             ,listeners: {
@@ -287,13 +285,13 @@ Ext.extend(MODx.grid.multiTVdbgrid,MODx.grid.Grid,{
     },unpublishSelected: function(btn,e) {
         var cs = this.getSelectedAsList();
         if (cs === false) return false;
-        
+
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
                 action: 'mgr/{/literal}{$customconfigs.task}{literal}/bulkupdate'
-				,configs: this.config.configs
-				,task: 'unpublish'
+                ,configs: this.config.configs
+                ,task: 'unpublish'
                 ,objects: cs
             }
             ,listeners: {
@@ -307,13 +305,13 @@ Ext.extend(MODx.grid.multiTVdbgrid,MODx.grid.Grid,{
     },deleteSelected: function(btn,e) {
         var cs = this.getSelectedAsList();
         if (cs === false) return false;
-        
+
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
                 action: 'mgr/{/literal}{$customconfigs.task}{literal}/bulkupdate'
-				,configs: this.config.configs
-				,task: 'delete'
+                ,configs: this.config.configs
+                ,task: 'delete'
                 ,objects: cs
             }
             ,listeners: {
@@ -329,9 +327,9 @@ Ext.extend(MODx.grid.multiTVdbgrid,MODx.grid.Grid,{
             url: this.config.url
             ,params: {
                 action: 'mgr/migxdb/update'
-				,task: 'delete'
+                ,task: 'delete'
                 ,object_id: this.menu.record.id
-				,configs: this.config.configs
+                ,configs: this.config.configs
             }
             ,listeners: {
                 'success': {fn:this.refresh,scope:this}
@@ -342,9 +340,9 @@ Ext.extend(MODx.grid.multiTVdbgrid,MODx.grid.Grid,{
             url: this.config.url
             ,params: {
                 action: 'mgr/migxdb/update'
-				,task: 'recall'
+                ,task: 'recall'
                 ,object_id: this.menu.record.id
-				,configs: this.config.configs
+                ,configs: this.config.configs
             }
             ,listeners: {
                 'success': {fn:this.refresh,scope:this}
@@ -355,105 +353,105 @@ Ext.extend(MODx.grid.multiTVdbgrid,MODx.grid.Grid,{
             url: this.config.url
             ,params: {
                 action: 'mgr/{/literal}{$customconfigs.task}{literal}/remove'
-				,task: 'removeone'
+                ,task: 'removeone'
                 ,object_id: this.menu.record.id
-				,configs: this.config.configs
+                ,configs: this.config.configs
             }
             ,listeners: {
                 'success': {fn:this.refresh,scope:this}
             }
         });
-    }                	     
-	,loadWin: function(btn,e,index,action) {
-	    var resource_id = '{/literal}{$resource.id}{literal}';
+    }
+    ,loadWin: function(btn,e,index,action) {
+        var resource_id = '{/literal}{$resource.id}{literal}';
         {/literal}{if $properties.autoResourceFolders == 'true'}{literal}
         if (resource_id == 0){
             alert ('{/literal}{$i18n.mig_save_resource}{literal}');
             return;
         }
-        {/literal}{/if}{literal}        
-       
+        {/literal}{/if}{literal}
+
         if (action == 'a'){
            //var json='{/literal}{$newitem}{literal}';
            //var data=Ext.util.JSON.decode(json);
            var object_id = 'new';
         }else{
-		   //var s = this.getStore();
-           //var rec = s.getAt(index)            
+           //var s = this.getStore();
+           //var rec = s.getAt(index)
            //var data = rec.data;
            //console.log(data);
            //var json = Ext.util.JSON.encode(rec.json);
            var object_id = this.menu.record.id;
         }
-        
+
         var isnew = (action == 'u') ? '0':'1';
-        
- 		
+
+
         var win_xtype = 'modx-window-tv-dbitem-update';
-		if (this.windows[win_xtype]){
-			this.windows[win_xtype].fp.autoLoad.params.tv_id='{/literal}{$tv->id}{literal}';
-			this.windows[win_xtype].fp.autoLoad.params.resource_id=resource_id;
+        if (this.windows[win_xtype]){
+            this.windows[win_xtype].fp.autoLoad.params.tv_id='{/literal}{$tv->id}{literal}';
+            this.windows[win_xtype].fp.autoLoad.params.resource_id=resource_id;
             this.windows[win_xtype].fp.autoLoad.params.configs=this.config.configs;
             this.windows[win_xtype].fp.autoLoad.params.tv_name='{/literal}{$tv->name}{literal}';
-		    //this.windows[win_xtype].fp.autoLoad.params.itemid=index;
+            //this.windows[win_xtype].fp.autoLoad.params.itemid=index;
             //this.windows[win_xtype].fp.autoLoad.params.record_json=json;
             //this.windows[win_xtype].fp.autoLoad.params.autoinc=this.autoinc;
             //this.windows[win_xtype].fp.autoLoad.params.isnew=isnew;
             this.windows[win_xtype].fp.autoLoad.params.object_id=object_id;
-			this.windows[win_xtype].grid=this;
+            this.windows[win_xtype].grid=this;
             this.windows[win_xtype].action=action;
-		}
-		this.loadWindow(btn,e,{
+        }
+        this.loadWindow(btn,e,{
             xtype: win_xtype
             //,record: data
-			,grid: this
+            ,grid: this
             ,action: action
             ,baseParams : {
-				//record_json:json,
-			    action: 'mgr/migxdb/fields',
-				tv_id: '{/literal}{$tv->id}{literal}',
-				tv_name: '{/literal}{$tv->name}{literal}',
-				'class_key': 'modDocument',
+                //record_json:json,
+                action: 'mgr/migxdb/fields',
+                tv_id: '{/literal}{$tv->id}{literal}',
+                tv_name: '{/literal}{$tv->name}{literal}',
+                'class_key': 'modDocument',
                 'wctx':'{/literal}{$myctx}{literal}',
-				//itemid : index,
+                //itemid : index,
                 //autoinc : this.autoinc,
                 object_id: object_id,
                 configs: this.config.configs,
                 //isnew : isnew,
                 resource_id : resource_id
-			}
+            }
         });
     }
-	,loadPreviewWin: function(btn,e,index,action) {
+    ,loadPreviewWin: function(btn,e,index,action) {
         var items = Ext.get('tv{/literal}{$tv->id}{literal}').dom.value;
-		//console.log((items));
+        //console.log((items));
         var jsonvarkey = '{/literal}{$properties.jsonvarkey}{literal}';
         if (jsonvarkey == ''){
             jsonvarkey = 'migx_outputvalue';
         }
         var win_xtype = 'modx-window-mi-preview';
-		if (this.windows[win_xtype]){
-			//this.windows[win_xtype].fp.autoLoad.params.tv_id='{/literal}{$tv->id}{literal}';
-			//this.windows[win_xtype].fp.autoLoad.params.tv_name='{/literal}{$tv->name}{literal}';
-		    //this.windows[win_xtype].fp.autoLoad.params.itemid=index;
+        if (this.windows[win_xtype]){
+            //this.windows[win_xtype].fp.autoLoad.params.tv_id='{/literal}{$tv->id}{literal}';
+            //this.windows[win_xtype].fp.autoLoad.params.tv_name='{/literal}{$tv->name}{literal}';
+            //this.windows[win_xtype].fp.autoLoad.params.itemid=index;
             //this.windows[win_xtype].fp.autoLoad.params.record_json=json;
             this.windows[win_xtype].src='{/literal}{$properties.previewurl}{literal}';
-			this.windows[win_xtype].json=items;
+            this.windows[win_xtype].json=items;
             this.windows[win_xtype].jsonvarkey=jsonvarkey;
             this.windows[win_xtype].action=action;
-		}
-		this.loadWindow(btn,e,{
+        }
+        this.loadWindow(btn,e,{
             xtype: win_xtype
             ,src: '{/literal}{$properties.previewurl}{literal}'
             ,jsonvarkey:jsonvarkey
             ,json: items
-			,grid: this
+            ,grid: this
             ,action: action
         });
-    }    	
+    }
     ,getMenu: function() {
-		var n = this.menu.record;
-        console.log(this.menu); 
+        var n = this.menu.record;
+        console.log(this.menu);
         var m = [];
         m.push({
             text: '{/literal}{$i18n.mig_edit}{literal}'
@@ -465,34 +463,34 @@ Ext.extend(MODx.grid.multiTVdbgrid,MODx.grid.Grid,{
             text: 'wiederherstellen'
             ,handler: this.recallObject
         });
-		m.push('-');
+        m.push('-');
         m.push({
             text: 'entfernen'
             ,handler: this.removeObject
-        });						
+        });
         } else if (n.deleted == 0) {
         m.push({
-            text: 'löschen'
+            text: 'lï¿½schen'
             ,handler: this.deleteObject
-        });		
-        }	        
-		return m;
+        });
+        }
+        return m;
     }
-	,collectItems: function(){
-		var items=[];
-		// read jsons from grid-store-items 
+    ,collectItems: function(){
+        var items=[];
+        // read jsons from grid-store-items
         var griddata=this.store.data;
-		for(i = 0; i <  griddata.length; i++) {
- 			items.push(griddata.items[i].json);
+        for(i = 0; i <  griddata.length; i++) {
+             items.push(griddata.items[i].json);
         }
         if (items.length >0){
-           Ext.get('tv{/literal}{$tv->id}{literal}').dom.value = Ext.util.JSON.encode(items); 
+           Ext.get('tv{/literal}{$tv->id}{literal}').dom.value = Ext.util.JSON.encode(items);
         }
         else{
-           Ext.get('tv{/literal}{$tv->id}{literal}').dom.value = '';  
+           Ext.get('tv{/literal}{$tv->id}{literal}').dom.value = '';
         }
-        
-		return;						 
+
+        return;
     }
 });
 Ext.reg('modx-grid-multitvdbgrid',MODx.grid.multiTVdbgrid);

--- a/core/components/migx/elements/tv/grids/dragdrop.grid.tpl
+++ b/core/components/migx/elements/tv/grids/dragdrop.grid.tpl
@@ -114,15 +114,15 @@ MODx.grid.multiTVdbgrid = function(config) {
             items: [{
                     text: 'Stapeloperationen',
                     menu: [{
-                        text: 'markierte ver�ffentlichen',
+                        text: 'markierte veröffentlichen',
                         handler: this.publishSelected,
                         scope: this
                     }, {
-                        text: 'markierte zur�ckziehen',
+                        text: 'markierte zurückziehen',
                         handler: this.unpublishSelected,
                         scope: this
                     }, {
-                        text: 'markierte l�schen',
+                        text: 'markierte löschen',
                         handler: this.deleteSelected,
                         scope: this
                     }]
@@ -470,7 +470,7 @@ Ext.extend(MODx.grid.multiTVdbgrid,MODx.grid.Grid,{
         });
         } else if (n.deleted == 0) {
         m.push({
-            text: 'l�schen'
+            text: 'löschen'
             ,handler: this.deleteObject
         });
         }

--- a/core/components/migx/elements/tv/grids/dragdrop.grid.tpl
+++ b/core/components/migx/elements/tv/grids/dragdrop.grid.tpl
@@ -151,9 +151,9 @@ Ext.extend(MODx.grid.multiTVdbgrid,MODx.grid.Grid,{
             return '<img style="height:60px" src="' + val + '"/>' ;
         }
         if (val != ''){
-            //return '<img src="{/literal}{$_config.connectors_url}{literal}system/phpthumb.php?w=80&h=80&f=png&ra=1&src=' + val + '" alt="" />';
+            //return '<img src="{/literal}{$_config.connectors_url}{literal}system/phpthumb.php?w=80&h=80&f=png&src=' + val + '" alt="" />';
 
-            return '<img src="'+MODx.config.connectors_url+'{/literal}system/phpthumb.php?w=80&h=80&f=png&ra=1&src='+val+'&wctx={$ctx}'+source+'{literal}" alt="" />';
+            return '<img src="'+MODx.config.connectors_url+'{/literal}system/phpthumb.php?w=80&h=80&f=png&src='+val+'&wctx={$ctx}'+source+'{literal}" alt="" />';
         }
         return val;
     }

--- a/core/components/migx/elements/tv/grids/markt.grid.tpl
+++ b/core/components/migx/elements/tv/grids/markt.grid.tpl
@@ -137,9 +137,9 @@ Ext.extend(MODx.grid.multiTVdbgrid,MODx.grid.Grid,{
             return '<img style="height:60px" src="' + val + '"/>' ;
         }
         if (val != ''){
-            //return '<img src="{/literal}{$_config.connectors_url}{literal}system/phpthumb.php?w=100&h=100&f=png&ra=1&src=' + val + '" alt="" />';
+            //return '<img src="{/literal}{$_config.connectors_url}{literal}system/phpthumb.php?w=80&h=80&f=png&ra=1&src=' + val + '" alt="" />';
 
-            return '<img src="'+MODx.config.connectors_url+'{/literal}system/phpthumb.php?w=100&h=100&f=png&ra=1&src='+val+'&wctx={$ctx}'+source+'{literal}" alt="" />';
+            return '<img src="'+MODx.config.connectors_url+'{/literal}system/phpthumb.php?w=80&h=80&f=png&ra=1&src='+val+'&wctx={$ctx}'+source+'{literal}" alt="" />';
         }
         return val;
     }

--- a/core/components/migx/elements/tv/grids/markt.grid.tpl
+++ b/core/components/migx/elements/tv/grids/markt.grid.tpl
@@ -137,9 +137,9 @@ Ext.extend(MODx.grid.multiTVdbgrid,MODx.grid.Grid,{
             return '<img style="height:60px" src="' + val + '"/>' ;
         }
         if (val != ''){
-            //return '<img src="{/literal}{$_config.connectors_url}{literal}system/phpthumb.php?w=80&h=80&f=png&ra=1&src=' + val + '" alt="" />';
+            //return '<img src="{/literal}{$_config.connectors_url}{literal}system/phpthumb.php?w=80&h=80&f=png&src=' + val + '" alt="" />';
 
-            return '<img src="'+MODx.config.connectors_url+'{/literal}system/phpthumb.php?w=80&h=80&f=png&ra=1&src='+val+'&wctx={$ctx}'+source+'{literal}" alt="" />';
+            return '<img src="'+MODx.config.connectors_url+'{/literal}system/phpthumb.php?w=80&h=80&f=png&src='+val+'&wctx={$ctx}'+source+'{literal}" alt="" />';
         }
         return val;
     }

--- a/core/components/migx/elements/tv/grids/markt.grid.tpl
+++ b/core/components/migx/elements/tv/grids/markt.grid.tpl
@@ -2,32 +2,32 @@
 
 MODx.grid.multiTVdbgrid = function(config) {
     config = config || {};
-	//console.log(config);
+    //console.log(config);
     Ext.applyIf(config,{
-	autoHeight: true,
+    autoHeight: true,
     collapsible: true,
-	resizable: true,
+    resizable: true,
     loadMask: true,
     paging: true,
     autosave: false,
     remoteSort: true,
     primaryKey: 'id',
-    isModified : false,    
+    isModified : false,
     ddGroup:'{/literal}{$tv->id}{literal}_gridDD',
     enableDragDrop: true, // enable drag and drop of grid rows
-	viewConfig: {
+    viewConfig: {
         emptyText: 'No items found',
         sm: new Ext.grid.RowSelectionModel({singleSelect:true}),
         forceFit: true,
-		autoFill: true
+        autoFill: true
     },
     url : config.url,
-    baseParams: { 
+    baseParams: {
         action: 'mgr/migxdb/getList',
         configs: config.configs,
         resource_id: config.resource_id,
         'HTTP_MODAUTH': config.auth},
-    fields: ['id','pagetitle','jobtitle','createdon','published','deleted'],    
+    fields: ['id','pagetitle','jobtitle','createdon','published','deleted'],
     columns: config.columns, // define grid columns in a separate variable
     listeners: {
         "render": {
@@ -63,21 +63,21 @@ MODx.grid.multiTVdbgrid = function(config) {
                                 for(i = 0; i <  rows.length; i++) {
                                 ds.remove(ds.getById(rows[i].id));
                                 }
-     							ds.insert(cindex,data.selections);
+                                 ds.insert(cindex,data.selections);
                                 sm.clearSelections();
                              }
                              MODx.fireResourceFormChange();
                          }
-						grid.collectItems();
+                        grid.collectItems();
                         grid.getView().refresh();
 
- 
+
                         // ************************************
                       }
-                   }) 
-		
-		this.setWidth('99%');
-		//this.syncSize();
+                   })
+
+        this.setWidth('99%');
+        //this.syncSize();
                    // load the grid store
                   //  after the grid has been rendered
                   //store.load();
@@ -85,7 +85,7 @@ MODx.grid.multiTVdbgrid = function(config) {
    }
 }
 
-		,tbar: [{
+        ,tbar: [{
             xtype: 'buttongroup',
             title: 'Aktionen',
             columns: 2,
@@ -93,85 +93,83 @@ MODx.grid.multiTVdbgrid = function(config) {
                 scale: 'large'
             },
             items: [{
-					text: 'xdbedit.bulk_actions',
-					menu: [{
-						text: 'xdbedit.publish_selected',
-						handler: this.publishSelected,
-						scope: this
-					}, {
-						text: 'xdbedit.unpublish_selected',
-						handler: this.unpublishSelected,
-						scope: this
-					}, {
-						text: 'xdbedit.delete_selected',
-						handler: this.deleteSelected,
-						scope: this
-					}]
-				},{
+                    text: 'xdbedit.bulk_actions',
+                    menu: [{
+                        text: 'xdbedit.publish_selected',
+                        handler: this.publishSelected,
+                        scope: this
+                    }, {
+                        text: 'xdbedit.unpublish_selected',
+                        handler: this.unpublishSelected,
+                        scope: this
+                    }, {
+                        text: 'xdbedit.delete_selected',
+                        handler: this.deleteSelected,
+                        scope: this
+                    }]
+                },{
                     text: ('{/literal}{$i18n.mig_show_trash}{literal}')
                     ,handler: this.toggleDeleted
                     ,enableToggle: true
                     ,scope: this
                 }]
-			
-			}         
-        
-        ]        
-		,viewConfig: {
+
+            }
+
+        ]
+        ,viewConfig: {
             forceFit:true
         }
-       
+
     });
-	
+
     MODx.grid.multiTVdbgrid.superclass.constructor.call(this,config)
     this.getStore().pathconfigs=config.pathconfigs;
-	//this.loadData();
+    //this.loadData();
 };
 Ext.extend(MODx.grid.multiTVdbgrid,MODx.grid.Grid,{
     _renderUrl: function(v,md,rec) {
         return '<a href="'+v+'" target="_blank">'+rec.data.pagetitle+'</a>';
     }
     ,renderImage : function(val, md, rec, row, col, s){
-		var source = s.pathconfigs[col];
-		if (val.substr(0,4) == 'http'){
-			return '<img style="height:60px" src="' + val + '"/>' ;
-		}        
-		if (val != ''){
-			//return '<img src="{/literal}{$_config.connectors_url}{literal}system/phpthumb.php?h=60&src=' + val + '" alt="" />';
-			
-			return '<img src="'+MODx.config.connectors_url+'{/literal}system/phpthumb.php?h=60&src='+val+'&wctx={$ctx}'+source+'{literal}" alt="" />';
-		
-		}
-		return val;
-	}
+        var source = s.pathconfigs[col];
+        if (val.substr(0,4) == 'http'){
+            return '<img style="height:60px" src="' + val + '"/>' ;
+        }
+        if (val != ''){
+            //return '<img src="{/literal}{$_config.connectors_url}{literal}system/phpthumb.php?w=100&h=100&f=png&ra=1&src=' + val + '" alt="" />';
+
+            return '<img src="'+MODx.config.connectors_url+'{/literal}system/phpthumb.php?w=100&h=100&f=png&ra=1&src='+val+'&wctx={$ctx}'+source+'{literal}" alt="" />';
+        }
+        return val;
+    }
     ,renderPlaceholder : function(val, md, rec, row, col, s){
         return '[[+'+val+'.'+rec.json.MIGX_id+']]';
-        
-	}       
+    }
     ,renderFirst : function(val, md, rec, row, col, s){
-		val = val.split(':');
+        val = val.split(':');
         return val[0];
-        
+
         /*
         var max = 100;
         var count = val.length;
-		if (count>max){
+        if (count>max){
             return(val.substring(0, max));
-		}
-        */        
-		return val;
-	}        
+        }
+        */
+        return val;
+    }
     ,renderLimited : function(val, md, rec, row, col, s){
-		var max = 100;
+        var max = 100;
         var count = val.length;
-		if (count>max){
+        if (count>max){
             return(val.substring(0, max));
-		}        
-		return val;
-	}    
+        }
+        return val;
+    }
     ,renderPreview : function(val,md,rec){
-		return val;
-	}
+        return val;
+    }
     ,toggleDeleted: function(btn,e) {
         var s = this.getStore();
         if (btn.pressed) {
@@ -197,120 +195,120 @@ Ext.extend(MODx.grid.multiTVdbgrid,MODx.grid.Grid,{
         cs = Ext.util.Format.substr(cs,1,cs.length-1);
         return cs;
     }
-	,addItem: function(btn,e) {
-		var s=this.getStore();
-		this.loadWin(btn,e,s.getCount(),'a');
-	}
-	,preview: function(btn,e) {
-		var s=this.getStore();
-		this.loadPreviewWin(btn,e,s.getCount(),'a');
-	}    	
-	,remove: function() {
+    ,addItem: function(btn,e) {
+        var s=this.getStore();
+        this.loadWin(btn,e,s.getCount(),'a');
+    }
+    ,preview: function(btn,e) {
+        var s=this.getStore();
+        this.loadPreviewWin(btn,e,s.getCount(),'a');
+    }
+    ,remove: function() {
         var _this=this;
-		Ext.Msg.confirm(_('warning') || '','{/literal}{$i18n.mig_remove_confirm}{literal}' || '',function(e) {
+        Ext.Msg.confirm(_('warning') || '','{/literal}{$i18n.mig_remove_confirm}{literal}' || '',function(e) {
             if (e == 'yes') {
-				_this.getStore().removeAt(_this.menu.recordIndex);
+                _this.getStore().removeAt(_this.menu.recordIndex);
                 _this.getView().refresh();
-		        _this.collectItems();
-                MODx.fireResourceFormChange();	
+                _this.collectItems();
+                MODx.fireResourceFormChange();
                 }
-            }),this;		
-	}   
-	,update: function(btn,e) {
+            }),this;
+    }
+    ,update: function(btn,e) {
       this.loadWin(btn,e,this.menu.recordIndex,'u');
     }
-	,duplicate: function(btn,e) {
+    ,duplicate: function(btn,e) {
       this.loadWin(btn,e,this.menu.recordIndex,'d');
-    }    
-	,loadWin: function(btn,e,index,action) {
-	    var resource_id = '{/literal}{$resource.id}{literal}';
+    }
+    ,loadWin: function(btn,e,index,action) {
+        var resource_id = '{/literal}{$resource.id}{literal}';
         {/literal}{if $properties.autoResourceFolders == 'true'}{literal}
         if (resource_id == 0){
             alert ('{/literal}{$i18n.mig_save_resource}{literal}');
             return;
         }
-        {/literal}{/if}{literal}        
-       
+        {/literal}{/if}{literal}
+
         if (action == 'a'){
            //var json='{/literal}{$newitem}{literal}';
            //var data=Ext.util.JSON.decode(json);
            var object_id = 'new';
         }else{
-		   //var s = this.getStore();
-           //var rec = s.getAt(index)            
+           //var s = this.getStore();
+           //var rec = s.getAt(index)
            //var data = rec.data;
            //console.log(data);
            //var json = Ext.util.JSON.encode(rec.json);
            var object_id = this.menu.record.id;
         }
-        
+
         var isnew = (action == 'u') ? '0':'1';
-        
- 		
+
+
         var win_xtype = 'modx-window-tv-dbitem-update';
-		if (this.windows[win_xtype]){
-			this.windows[win_xtype].fp.autoLoad.params.tv_id='{/literal}{$tv->id}{literal}';
-			this.windows[win_xtype].fp.autoLoad.params.resource_id=resource_id;
+        if (this.windows[win_xtype]){
+            this.windows[win_xtype].fp.autoLoad.params.tv_id='{/literal}{$tv->id}{literal}';
+            this.windows[win_xtype].fp.autoLoad.params.resource_id=resource_id;
             this.windows[win_xtype].fp.autoLoad.params.tv_name='{/literal}{$tv->name}{literal}';
             this.windows[win_xtype].fp.autoLoad.params.configs=this.config.configs;
-		    //this.windows[win_xtype].fp.autoLoad.params.itemid=index;
+            //this.windows[win_xtype].fp.autoLoad.params.itemid=index;
             //this.windows[win_xtype].fp.autoLoad.params.record_json=json;
             //this.windows[win_xtype].fp.autoLoad.params.autoinc=this.autoinc;
             //this.windows[win_xtype].fp.autoLoad.params.isnew=isnew;
             this.windows[win_xtype].fp.autoLoad.params.object_id=object_id;
-			this.windows[win_xtype].grid=this;
+            this.windows[win_xtype].grid=this;
             this.windows[win_xtype].action=action;
-		}
-		this.loadWindow(btn,e,{
+        }
+        this.loadWindow(btn,e,{
             xtype: win_xtype
             //,record: data
-			,grid: this
+            ,grid: this
             ,action: action
             ,baseParams : {
-				//record_json:json,
-			    action: 'mgr/migxdb/fields',
-				tv_id: '{/literal}{$tv->id}{literal}',
-				tv_name: '{/literal}{$tv->name}{literal}',
-				'class_key': 'modDocument',
+                //record_json:json,
+                action: 'mgr/migxdb/fields',
+                tv_id: '{/literal}{$tv->id}{literal}',
+                tv_name: '{/literal}{$tv->name}{literal}',
+                'class_key': 'modDocument',
                 'wctx':'{/literal}{$myctx}{literal}',
-				//itemid : index,
+                //itemid : index,
                 //autoinc : this.autoinc,
                 object_id: object_id,
                 configs: this.config.configs,
                 //isnew : isnew,
                 resource_id : resource_id
-			}
+            }
         });
     }
-	,loadPreviewWin: function(btn,e,index,action) {
+    ,loadPreviewWin: function(btn,e,index,action) {
         var items = Ext.get('tv{/literal}{$tv->id}{literal}').dom.value;
-		//console.log((items));
+        //console.log((items));
         var jsonvarkey = '{/literal}{$properties.jsonvarkey}{literal}';
         if (jsonvarkey == ''){
             jsonvarkey = 'migx_outputvalue';
         }
         var win_xtype = 'modx-window-mi-preview';
-		if (this.windows[win_xtype]){
-			//this.windows[win_xtype].fp.autoLoad.params.tv_id='{/literal}{$tv->id}{literal}';
-			//this.windows[win_xtype].fp.autoLoad.params.tv_name='{/literal}{$tv->name}{literal}';
-		    //this.windows[win_xtype].fp.autoLoad.params.itemid=index;
+        if (this.windows[win_xtype]){
+            //this.windows[win_xtype].fp.autoLoad.params.tv_id='{/literal}{$tv->id}{literal}';
+            //this.windows[win_xtype].fp.autoLoad.params.tv_name='{/literal}{$tv->name}{literal}';
+            //this.windows[win_xtype].fp.autoLoad.params.itemid=index;
             //this.windows[win_xtype].fp.autoLoad.params.record_json=json;
             this.windows[win_xtype].src='{/literal}{$properties.previewurl}{literal}';
-			this.windows[win_xtype].json=items;
+            this.windows[win_xtype].json=items;
             this.windows[win_xtype].jsonvarkey=jsonvarkey;
             this.windows[win_xtype].action=action;
-		}
-		this.loadWindow(btn,e,{
+        }
+        this.loadWindow(btn,e,{
             xtype: win_xtype
             ,src: '{/literal}{$properties.previewurl}{literal}'
             ,jsonvarkey:jsonvarkey
             ,json: items
-			,grid: this
+            ,grid: this
             ,action: action
         });
-    }    	
+    }
     ,getMenu: function() {
-		var n = this.menu.record; 
+        var n = this.menu.record;
         var m = [];
         m.push({
             text: '{/literal}{$i18n.mig_edit}{literal}'
@@ -319,29 +317,29 @@ Ext.extend(MODx.grid.multiTVdbgrid,MODx.grid.Grid,{
         m.push({
             text: '{/literal}{$i18n.mig_duplicate}{literal}'
             ,handler: this.duplicate
-        });        
+        });
         m.push('-');
         m.push({
             text: '{/literal}{$i18n.mig_remove}{literal}'
             ,handler: this.remove
         });
-		return m;
+        return m;
     }
-	,collectItems: function(){
-		var items=[];
-		// read jsons from grid-store-items 
+    ,collectItems: function(){
+        var items=[];
+        // read jsons from grid-store-items
         var griddata=this.store.data;
-		for(i = 0; i <  griddata.length; i++) {
- 			items.push(griddata.items[i].json);
+        for(i = 0; i <  griddata.length; i++) {
+             items.push(griddata.items[i].json);
         }
         if (items.length >0){
-           Ext.get('tv{/literal}{$tv->id}{literal}').dom.value = Ext.util.JSON.encode(items); 
+           Ext.get('tv{/literal}{$tv->id}{literal}').dom.value = Ext.util.JSON.encode(items);
         }
         else{
-           Ext.get('tv{/literal}{$tv->id}{literal}').dom.value = '';  
+           Ext.get('tv{/literal}{$tv->id}{literal}').dom.value = '';
         }
-        
-		return;						 
+
+        return;
     }
 });
 Ext.reg('modx-grid-multitvdbgrid',MODx.grid.multiTVdbgrid);

--- a/core/components/migx/elements/tv/grids/reparaturliste.grid.tpl
+++ b/core/components/migx/elements/tv/grids/reparaturliste.grid.tpl
@@ -118,9 +118,9 @@ Ext.extend(MODx.grid.multiTVdbgrid,MODx.grid.Grid,{
             return '<img style="height:60px" src="' + val + '"/>' ;
         }
         if (val != ''){
-            //return '<img src="{/literal}{$_config.connectors_url}{literal}system/phpthumb.php?w=100&h=100&f=png&ra=1&src=' + val + '" alt="" />';
+            //return '<img src="{/literal}{$_config.connectors_url}{literal}system/phpthumb.php?w=80&h=80&f=png&ra=1&src=' + val + '" alt="" />';
 
-            return '<img src="'+MODx.config.connectors_url+'{/literal}system/phpthumb.php?w=100&h=100&f=png&ra=1&src='+val+'&wctx={$ctx}'+source+'{literal}" alt="" />';
+            return '<img src="'+MODx.config.connectors_url+'{/literal}system/phpthumb.php?w=80&h=80&f=png&ra=1&src='+val+'&wctx={$ctx}'+source+'{literal}" alt="" />';
         }
         return val;
     }

--- a/core/components/migx/elements/tv/grids/reparaturliste.grid.tpl
+++ b/core/components/migx/elements/tv/grids/reparaturliste.grid.tpl
@@ -2,73 +2,73 @@
 
 MODx.grid.multiTVdbgrid = function(config) {
     config = config || {};
-	//console.log(config);
+    //console.log(config);
     this.sm = new Ext.grid.CheckboxSelectionModel();
 
     // define grid columns in a separate variable
     var cols=[this.sm];
-	for(i = 0; i <  config.columns.length; i++) {
- 		cols.push(config.columns[i]);
-    } 
+    for(i = 0; i <  config.columns.length; i++) {
+         cols.push(config.columns[i]);
+    }
     config.columns=cols;
-        
+
     Ext.applyIf(config,{
-	autoHeight: true,
+    autoHeight: true,
     collapsible: true,
-	resizable: true,
+    resizable: true,
     loadMask: true,
     paging: true,
     autosave: false,
     remoteSort: true,
     pageSize: 10,
     primaryKey: 'id',
-    isModified : false,    
+    isModified : false,
     sm: this.sm,
-	viewConfig: {
+    viewConfig: {
         emptyText: 'No items found',
         forceFit: true,
-		autoFill: true,
+        autoFill: true,
         getRowClass : function(rec, ri, p){
             var cls = 'xdbedit-object';
             if (!rec.data.published) cls += ' xdbedit-unpublished';
             if (rec.data.deleted) cls += ' xdbedit-deleted';
 
             return cls;
-        }        
+        }
     },
     url : config.url,
-    baseParams: { 
+    baseParams: {
         action: 'mgr/migxdb/getList',
         configs: config.configs,
         resource_id: config.resource_id,
         'HTTP_MODAUTH': config.auth},
-    fields: ['id','pagetitle','content','createdon','published','deleted'],    
+    fields: ['id','pagetitle','content','createdon','published','deleted'],
         columns: []
 
-		,tbar: [{
-				xtype: 'buttongroup',
-				id: 'filter-buttongroup',
-				title: 'Filter',
-				columns: 2,
-				defaults: {
-					scale: 'large'
-				},
-				items: [{
-					text: 'Status:'
-				}, {
-					xtype: 'migx-combo-status',
-					id: 'migx-filter-status',
-					itemId: 'status',
-					value: 'all',
-					width: 150,
-					listeners: {
-						'select': {
-							fn: this.changeStatus,
-							scope: this
-						}
-					}
-				}]
-			},{
+        ,tbar: [{
+                xtype: 'buttongroup',
+                id: 'filter-buttongroup',
+                title: 'Filter',
+                columns: 2,
+                defaults: {
+                    scale: 'large'
+                },
+                items: [{
+                    text: 'Status:'
+                }, {
+                    xtype: 'migx-combo-status',
+                    id: 'migx-filter-status',
+                    itemId: 'status',
+                    value: 'all',
+                    width: 150,
+                    listeners: {
+                        'select': {
+                            fn: this.changeStatus,
+                            scope: this
+                        }
+                    }
+                }]
+            },{
             xtype: 'buttongroup',
             title: 'Aktionen',
             columns: 2,
@@ -76,83 +76,81 @@ MODx.grid.multiTVdbgrid = function(config) {
                 scale: 'large'
             },
             items: [{
-					text: 'Stapeloperationen',
-					menu: [{
-						text: 'markierte veröffentlichen',
-						handler: this.publishSelected,
-						scope: this
-					}, {
-						text: 'markierte zurückziehen',
-						handler: this.unpublishSelected,
-						scope: this
-					}, {
-						text: 'markierte löschen',
-						handler: this.deleteSelected,
-						scope: this
-					}]
-				},{
+                    text: 'Stapeloperationen',
+                    menu: [{
+                        text: 'markierte veröffentlichen',
+                        handler: this.publishSelected,
+                        scope: this
+                    }, {
+                        text: 'markierte zurückziehen',
+                        handler: this.unpublishSelected,
+                        scope: this
+                    }, {
+                        text: 'markierte löschen',
+                        handler: this.deleteSelected,
+                        scope: this
+                    }]
+                },{
                     text: ('{/literal}{$i18n.mig_show_trash}{literal}')
                     ,handler: this.toggleDeleted
                     ,enableToggle: true
                     ,scope: this
                 }]
-			
-			}         
-        
-        ]        
 
-       
+            }
+
+        ]
+
+
     });
-	
+
     MODx.grid.multiTVdbgrid.superclass.constructor.call(this,config)
     this.getStore().pathconfigs=config.pathconfigs;
-	//this.loadData();
+    //this.loadData();
 };
 Ext.extend(MODx.grid.multiTVdbgrid,MODx.grid.Grid,{
     _renderUrl: function(v,md,rec) {
         return '<a href="'+v+'" target="_blank">'+rec.data.pagetitle+'</a>';
     }
     ,renderImage : function(val, md, rec, row, col, s){
-		var source = s.pathconfigs[col];
-		if (val.substr(0,4) == 'http'){
-			return '<img style="height:60px" src="' + val + '"/>' ;
-		}        
-		if (val != ''){
-			//return '<img src="{/literal}{$_config.connectors_url}{literal}system/phpthumb.php?h=60&src=' + val + '" alt="" />';
-			
-			return '<img src="'+MODx.config.connectors_url+'{/literal}system/phpthumb.php?h=60&src='+val+'&wctx={$ctx}'+source+'{literal}" alt="" />';
-		
-		}
-		return val;
-	}
+        var source = s.pathconfigs[col];
+        if (val.substr(0,4) == 'http'){
+            return '<img style="height:60px" src="' + val + '"/>' ;
+        }
+        if (val != ''){
+            //return '<img src="{/literal}{$_config.connectors_url}{literal}system/phpthumb.php?w=100&h=100&f=png&ra=1&src=' + val + '" alt="" />';
+
+            return '<img src="'+MODx.config.connectors_url+'{/literal}system/phpthumb.php?w=100&h=100&f=png&ra=1&src='+val+'&wctx={$ctx}'+source+'{literal}" alt="" />';
+        }
+        return val;
+    }
     ,renderPlaceholder : function(val, md, rec, row, col, s){
         return '[[+'+val+'.'+rec.json.MIGX_id+']]';
-        
-	}       
+    }
     ,renderFirst : function(val, md, rec, row, col, s){
-		val = val.split(':');
+        val = val.split(':');
         return val[0];
-        
+
         /*
         var max = 100;
         var count = val.length;
-		if (count>max){
+        if (count>max){
             return(val.substring(0, max));
-		}
-        */        
-		return val;
-	}        
+        }
+        */
+        return val;
+    }
     ,renderLimited : function(val, md, rec, row, col, s){
-		var max = 100;
+        var max = 100;
         var count = val.length;
-		if (count>max){
+        if (count>max){
             return(val.substring(0, max));
-		}        
-		return val;
-	}    
+        }
+        return val;
+    }
     ,renderPreview : function(val,md,rec){
-		return val;
-	}
+        return val;
+    }
     ,toggleDeleted: function(btn,e) {
         var s = this.getStore();
         if (btn.pressed) {
@@ -167,7 +165,7 @@ Ext.extend(MODx.grid.multiTVdbgrid,MODx.grid.Grid,{
         this.refresh();
     }
 
-	,getSelectedAsList: function() {
+    ,getSelectedAsList: function() {
         var sels = this.getSelectionModel().getSelections();
         if (sels.length <= 0) return false;
 
@@ -180,13 +178,13 @@ Ext.extend(MODx.grid.multiTVdbgrid,MODx.grid.Grid,{
     },publishSelected: function(btn,e) {
         var cs = this.getSelectedAsList();
         if (cs === false) return false;
-        
+
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
                 action: 'mgr/{/literal}{$customconfigs.task}{literal}/bulkupdate'
-				,configs: this.config.configs
-				,task: 'publish'
+                ,configs: this.config.configs
+                ,task: 'publish'
                 ,objects: cs
             }
             ,listeners: {
@@ -200,13 +198,13 @@ Ext.extend(MODx.grid.multiTVdbgrid,MODx.grid.Grid,{
     },unpublishSelected: function(btn,e) {
         var cs = this.getSelectedAsList();
         if (cs === false) return false;
-        
+
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
                 action: 'mgr/{/literal}{$customconfigs.task}{literal}/bulkupdate'
-				,configs: this.config.configs
-				,task: 'unpublish'
+                ,configs: this.config.configs
+                ,task: 'unpublish'
                 ,objects: cs
             }
             ,listeners: {
@@ -220,13 +218,13 @@ Ext.extend(MODx.grid.multiTVdbgrid,MODx.grid.Grid,{
     },deleteSelected: function(btn,e) {
         var cs = this.getSelectedAsList();
         if (cs === false) return false;
-        
+
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
                 action: 'mgr/{/literal}{$customconfigs.task}{literal}/bulkupdate'
-				,configs: this.config.configs
-				,task: 'delete'
+                ,configs: this.config.configs
+                ,task: 'delete'
                 ,objects: cs
             }
             ,listeners: {
@@ -238,32 +236,32 @@ Ext.extend(MODx.grid.multiTVdbgrid,MODx.grid.Grid,{
         });
         return true;
     }
-	,addItem: function(btn,e) {
-		var s=this.getStore();
-		this.loadWin(btn,e,s.getCount(),'a');
-	}
-	,preview: function(btn,e) {
-		var s=this.getStore();
-		this.loadPreviewWin(btn,e,s.getCount(),'a');
-	}
-	,changeStatus: function(cb,nv,ov) {
+    ,addItem: function(btn,e) {
+        var s=this.getStore();
+        this.loadWin(btn,e,s.getCount(),'a');
+    }
+    ,preview: function(btn,e) {
+        var s=this.getStore();
+        this.loadPreviewWin(btn,e,s.getCount(),'a');
+    }
+    ,changeStatus: function(cb,nv,ov) {
         this.setFilterParams({
-			status:cb.getValue()
-		});      		
+            status:cb.getValue()
+        });
     }
     ,setFilterParams: function(params) {
         var tb = this.getTopToolbar();
         if (!tb) {return false;}
         //var ccb = null;
-		//var ycb = null;
-		//var mcb = null;
+        //var ycb = null;
+        //var mcb = null;
         if (params.status) {
             //params.month = params.month||'all';
-			//params.year = params.year||'all';
-			//Ext.getCmp('migx-filter-status').setValue(params.status);
+            //params.year = params.year||'all';
+            //Ext.getCmp('migx-filter-status').setValue(params.status);
             //ycb = tb.getComponent('year');
-			//ycb = Ext.getCmp('xdbedit-filter-year');
-			
+            //ycb = Ext.getCmp('xdbedit-filter-year');
+
             /*
             if (ycb) {
                 ycb.store.baseParams['region'] = params.region;
@@ -274,42 +272,42 @@ Ext.extend(MODx.grid.multiTVdbgrid,MODx.grid.Grid,{
                 });
             }
             */
-        } 
+        }
         /*
         if (params.year) {
             params.month = params.month||'all';
-			Ext.getCmp('xdbedit-filter-year').setValue(params.year);
+            Ext.getCmp('xdbedit-filter-year').setValue(params.year);
             //mcb = tb.getComponent('month');
-			mcb = Ext.getCmp('xdbedit-filter-month');
+            mcb = Ext.getCmp('xdbedit-filter-month');
             if (mcb) {
                 mcb.store.baseParams['year'] = params.year;
-				if (params.region) {mcb.store.baseParams['region'] = params.region;}
+                if (params.region) {mcb.store.baseParams['region'] = params.region;}
                 mcb.store.load({
                     callback: function() {
                         mcb.setValue(params.month);
                     }
                 });
             }
-        } 
+        }
         */
         var s = this.getStore();
         if (s) {
             //if (params.year) {s.baseParams['year'] = params.year;}
             //if (params.month) {s.baseParams['month'] = params.month ;}
-			if (params.status) {s.baseParams['status'] = params.status ;}
+            if (params.status) {s.baseParams['status'] = params.status ;}
             s.removeAll();
         }
         this.getBottomToolbar().changePage(1);
         this.refresh();
     }
-	,deleteObject: function() {
+    ,deleteObject: function() {
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
                 action: 'mgr/migxdb/update'
-				,task: 'delete'
+                ,task: 'delete'
                 ,object_id: this.menu.record.id
-				,configs: this.config.configs
+                ,configs: this.config.configs
             }
             ,listeners: {
                 'success': {fn:this.refresh,scope:this}
@@ -320,9 +318,9 @@ Ext.extend(MODx.grid.multiTVdbgrid,MODx.grid.Grid,{
             url: this.config.url
             ,params: {
                 action: 'mgr/migxdb/update'
-				,task: 'recall'
+                ,task: 'recall'
                 ,object_id: this.menu.record.id
-				,configs: this.config.configs
+                ,configs: this.config.configs
             }
             ,listeners: {
                 'success': {fn:this.refresh,scope:this}
@@ -333,122 +331,121 @@ Ext.extend(MODx.grid.multiTVdbgrid,MODx.grid.Grid,{
             url: this.config.url
             ,params: {
                 action: 'mgr/{/literal}{$customconfigs.task}{literal}/remove'
-				,task: 'removeone'
+                ,task: 'removeone'
                 ,object_id: this.menu.record.id
-				,configs: this.config.configs
+                ,configs: this.config.configs
             }
             ,listeners: {
                 'success': {fn:this.refresh,scope:this}
             }
         });
-    }                	
-	,remove: function() {
+    }
+    ,remove: function() {
         var _this=this;
-		Ext.Msg.confirm(_('warning') || '','{/literal}{$i18n.mig_remove_confirm}{literal}' || '',function(e) {
+        Ext.Msg.confirm(_('warning') || '','{/literal}{$i18n.mig_remove_confirm}{literal}' || '',function(e) {
             if (e == 'yes') {
-				_this.getStore().removeAt(_this.menu.recordIndex);
+                _this.getStore().removeAt(_this.menu.recordIndex);
                 _this.getView().refresh();
-		        _this.collectItems();
-                MODx.fireResourceFormChange();	
+                _this.collectItems();
+                MODx.fireResourceFormChange();
                 }
-            }),this;		
-	}   
-	,update: function(btn,e) {
+            }),this;
+    }
+    ,update: function(btn,e) {
       this.loadWin(btn,e,this.menu.recordIndex,'u');
     }
-	,duplicate: function(btn,e) {
+    ,duplicate: function(btn,e) {
       this.loadWin(btn,e,this.menu.recordIndex,'d');
-    }    
-	,loadWin: function(btn,e,index,action) {
-	    var resource_id = '{/literal}{$resource.id}{literal}';
+    }
+    ,loadWin: function(btn,e,index,action) {
+        var resource_id = '{/literal}{$resource.id}{literal}';
         {/literal}{if $properties.autoResourceFolders == 'true'}{literal}
         if (resource_id == 0){
             alert ('{/literal}{$i18n.mig_save_resource}{literal}');
             return;
         }
-        {/literal}{/if}{literal}        
-       
+        {/literal}{/if}{literal}
+
         if (action == 'a'){
            //var json='{/literal}{$newitem}{literal}';
            //var data=Ext.util.JSON.decode(json);
            var object_id = 'new';
         }else{
-		   //var s = this.getStore();
-           //var rec = s.getAt(index)            
+           //var s = this.getStore();
+           //var rec = s.getAt(index)
            //var data = rec.data;
            //console.log(data);
            //var json = Ext.util.JSON.encode(rec.json);
            var object_id = this.menu.record.id;
         }
-        
+
         var isnew = (action == 'u') ? '0':'1';
-        
- 		
+
         var win_xtype = 'modx-window-tv-dbitem-update';
-		if (this.windows[win_xtype]){
-			this.windows[win_xtype].fp.autoLoad.params.tv_id='{/literal}{$tv->id}{literal}';
-			this.windows[win_xtype].fp.autoLoad.params.resource_id=resource_id;
+        if (this.windows[win_xtype]){
+            this.windows[win_xtype].fp.autoLoad.params.tv_id='{/literal}{$tv->id}{literal}';
+            this.windows[win_xtype].fp.autoLoad.params.resource_id=resource_id;
             this.windows[win_xtype].fp.autoLoad.params.tv_name='{/literal}{$tv->name}{literal}';
             this.windows[win_xtype].fp.autoLoad.params.configs=this.config.configs;
-		    //this.windows[win_xtype].fp.autoLoad.params.itemid=index;
+            //this.windows[win_xtype].fp.autoLoad.params.itemid=index;
             //this.windows[win_xtype].fp.autoLoad.params.record_json=json;
             //this.windows[win_xtype].fp.autoLoad.params.autoinc=this.autoinc;
             //this.windows[win_xtype].fp.autoLoad.params.isnew=isnew;
             this.windows[win_xtype].fp.autoLoad.params.object_id=object_id;
-			this.windows[win_xtype].grid=this;
+            this.windows[win_xtype].grid=this;
             this.windows[win_xtype].action=action;
-		}
-		this.loadWindow(btn,e,{
+        }
+        this.loadWindow(btn,e,{
             xtype: win_xtype
             //,record: data
-			,grid: this
+            ,grid: this
             ,action: action
             ,baseParams : {
-				//record_json:json,
-			    action: 'mgr/migxdb/fields',
-				tv_id: '{/literal}{$tv->id}{literal}',
-				tv_name: '{/literal}{$tv->name}{literal}',
-				'class_key': 'modDocument',
+                //record_json:json,
+                action: 'mgr/migxdb/fields',
+                tv_id: '{/literal}{$tv->id}{literal}',
+                tv_name: '{/literal}{$tv->name}{literal}',
+                'class_key': 'modDocument',
                 'wctx':'{/literal}{$myctx}{literal}',
-				//itemid : index,
+                //itemid : index,
                 //autoinc : this.autoinc,
                 object_id: object_id,
                 configs: this.config.configs,
                 //isnew : isnew,
                 resource_id : resource_id
-			}
+            }
         });
     }
-	,loadPreviewWin: function(btn,e,index,action) {
+    ,loadPreviewWin: function(btn,e,index,action) {
         var items = Ext.get('tv{/literal}{$tv->id}{literal}').dom.value;
-		//console.log((items));
+        //console.log((items));
         var jsonvarkey = '{/literal}{$properties.jsonvarkey}{literal}';
         if (jsonvarkey == ''){
             jsonvarkey = 'migx_outputvalue';
         }
         var win_xtype = 'modx-window-mi-preview';
-		if (this.windows[win_xtype]){
-			//this.windows[win_xtype].fp.autoLoad.params.tv_id='{/literal}{$tv->id}{literal}';
-			//this.windows[win_xtype].fp.autoLoad.params.tv_name='{/literal}{$tv->name}{literal}';
-		    //this.windows[win_xtype].fp.autoLoad.params.itemid=index;
+        if (this.windows[win_xtype]){
+            //this.windows[win_xtype].fp.autoLoad.params.tv_id='{/literal}{$tv->id}{literal}';
+            //this.windows[win_xtype].fp.autoLoad.params.tv_name='{/literal}{$tv->name}{literal}';
+            //this.windows[win_xtype].fp.autoLoad.params.itemid=index;
             //this.windows[win_xtype].fp.autoLoad.params.record_json=json;
             this.windows[win_xtype].src='{/literal}{$properties.previewurl}{literal}';
-			this.windows[win_xtype].json=items;
+            this.windows[win_xtype].json=items;
             this.windows[win_xtype].jsonvarkey=jsonvarkey;
             this.windows[win_xtype].action=action;
-		}
-		this.loadWindow(btn,e,{
+        }
+        this.loadWindow(btn,e,{
             xtype: win_xtype
             ,src: '{/literal}{$properties.previewurl}{literal}'
             ,jsonvarkey:jsonvarkey
             ,json: items
-			,grid: this
+            ,grid: this
             ,action: action
         });
-    }    	
+    }
     ,getMenu: function() {
-		var n = this.menu.record;
-        console.log(this.menu); 
+        var n = this.menu.record;
+        console.log(this.menu);
         var m = [];
         m.push({
             text: '{/literal}{$i18n.mig_edit}{literal}'
@@ -460,39 +457,37 @@ Ext.extend(MODx.grid.multiTVdbgrid,MODx.grid.Grid,{
             text: 'wiederherstellen'
             ,handler: this.recallObject
         });
-		m.push('-');
+        m.push('-');
         m.push({
             text: 'entfernen'
             ,handler: this.removeObject
-        });						
+        });
         } else if (n.deleted == 0) {
         m.push({
             text: 'löschen'
             ,handler: this.deleteObject
-        });		
-        }	        
-		return m;
+        });
+        }
+        return m;
     }
-	,collectItems: function(){
-		var items=[];
-		// read jsons from grid-store-items 
+    ,collectItems: function(){
+        var items=[];
+        // read jsons from grid-store-items
         var griddata=this.store.data;
-		for(i = 0; i <  griddata.length; i++) {
- 			items.push(griddata.items[i].json);
+        for(i = 0; i <  griddata.length; i++) {
+             items.push(griddata.items[i].json);
         }
         if (items.length >0){
-           Ext.get('tv{/literal}{$tv->id}{literal}').dom.value = Ext.util.JSON.encode(items); 
+           Ext.get('tv{/literal}{$tv->id}{literal}').dom.value = Ext.util.JSON.encode(items);
         }
         else{
-           Ext.get('tv{/literal}{$tv->id}{literal}').dom.value = '';  
+           Ext.get('tv{/literal}{$tv->id}{literal}').dom.value = '';
         }
-        
-		return;						 
+
+        return;
     }
 });
 Ext.reg('modx-grid-multitvdbgrid',MODx.grid.multiTVdbgrid);
-
-
 
 MODx.combo.Status = function(config) {
     config = config || {};
@@ -503,17 +498,17 @@ MODx.combo.Status = function(config) {
         ,typeAhead: false
         ,editable: false
         ,allowBlank: false
-        ,listWidth: 300		
-		,resizable: false
-        ,pageSize: 0		
+        ,listWidth: 300
+        ,resizable: false
+        ,pageSize: 0
         ,url: MODx.config.assets_url+'components/migx/connector.php'
         ,fields: ['name']
         ,displayField: 'name'
         ,valueField: 'name'
         ,baseParams: {
-		    action: 'mgr/{/literal}{$customconfigs.task}{literal}/gettvoptions',
+            action: 'mgr/{/literal}{$customconfigs.task}{literal}/gettvoptions',
             tvname: 'auftrag_status',
-			configs: '{/literal}{$properties.configs}{literal}',
+            configs: '{/literal}{$properties.configs}{literal}',
         }
     });
     MODx.combo.Status.superclass.constructor.call(this,config);

--- a/core/components/migx/elements/tv/grids/reparaturliste.grid.tpl
+++ b/core/components/migx/elements/tv/grids/reparaturliste.grid.tpl
@@ -118,9 +118,9 @@ Ext.extend(MODx.grid.multiTVdbgrid,MODx.grid.Grid,{
             return '<img style="height:60px" src="' + val + '"/>' ;
         }
         if (val != ''){
-            //return '<img src="{/literal}{$_config.connectors_url}{literal}system/phpthumb.php?w=80&h=80&f=png&ra=1&src=' + val + '" alt="" />';
+            //return '<img src="{/literal}{$_config.connectors_url}{literal}system/phpthumb.php?w=80&h=80&f=png&src=' + val + '" alt="" />';
 
-            return '<img src="'+MODx.config.connectors_url+'{/literal}system/phpthumb.php?w=80&h=80&f=png&ra=1&src='+val+'&wctx={$ctx}'+source+'{literal}" alt="" />';
+            return '<img src="'+MODx.config.connectors_url+'{/literal}system/phpthumb.php?w=80&h=80&f=png&src='+val+'&wctx={$ctx}'+source+'{literal}" alt="" />';
         }
         return val;
     }

--- a/core/components/migx/elements/tv/migx_one.tpl
+++ b/core/components/migx/elements/tv/migx_one.tpl
@@ -10,27 +10,27 @@
 
 MODx.grid.multiTVgrid = function(config) {
     config = config || {};
-	Ext.applyIf(config,{
-	autoHeight: true,
+    Ext.applyIf(config,{
+    autoHeight: true,
     collapsible: true,
-	resizable: true,
+    resizable: true,
     store: 	new Ext.data.JsonStore({
         fields : config.fields
-    }), // define the data store in a separate variable		
+    }), // define the data store in a separate variable
     loadMask: true,
-	viewConfig: {
+    viewConfig: {
         emptyText: 'No items found',
         sm: new Ext.grid.RowSelectionModel({singleSelect:true}),
         forceFit: true,
-		autoFill: true
-    }, 
-	columns: config.columns, // define grid columns in a separate variable
+        autoFill: true
+    },
+    columns: config.columns, // define grid columns in a separate variable
     listeners: {
         "render": {
             scope: this,
             fn: function(grid) {
-		        this.setWidth('99%');
-		        //this.syncSize();
+                this.setWidth('99%');
+                //this.syncSize();
                 //load the grid store
                 //after the grid has been rendered
                 //store.load();
@@ -38,113 +38,112 @@ MODx.grid.multiTVgrid = function(config) {
         }
     }
 
-		,tbar: [{
+        ,tbar: [{
             text: '{/literal}{$i18n.mig_edit}{literal}',
-			handler: this.update
-        }]        
-		,viewConfig: {
+            handler: this.update
+        }]
+        ,viewConfig: {
             forceFit:true
         }
     });
-	
+
     MODx.grid.multiTVgrid.superclass.constructor.call(this,config)
     this.getStore().pathconfigs=config.pathconfigs;
-	this.loadData();
+    this.loadData();
 };
 Ext.extend(MODx.grid.multiTVgrid,MODx.grid.LocalGrid,{
     _renderUrl: function(v,md,rec) {
         return '<a href="'+v+'" target="_blank">'+rec.data.pagetitle+'</a>';
     }
     ,renderImage : function(val, md, rec, row, col, s){
-		var pc = s.pathconfigs[col];
-		if (val.substr(0,4) == 'http'){
-			return '<img style="height:60px" src="' + val + '"/>' ;
-		}        
-		if (val != ''){
-			//return '<img src="{/literal}{$_config.connectors_url}{literal}system/phpthumb.php?h=60&src=' + val + '" alt="" />';
-			
-			return '<img src="'+MODx.config.connectors_url+'{/literal}system/phpthumb.php?h=60&src='+val+'&wctx={$ctx}&basePath='+pc.basePath+'&basePathRelative='+pc.basePathRelative+'&baseUrl='+pc.baseUrl+'&baseUrlRelative='+pc.baseUrlRelative+'{literal}" alt="" />';
-		
-		}
-		return val;
-	}
-    ,renderLimited : function(val, md, rec, row, col, s){
-		var max = 100;
-        var count = val.length;
-		if (count>max){
-            return(val.substring(0, max));
-		}        
-		return val;
-	}    
-    ,renderPreview : function(val,md,rec){
-		return val;
-	}
+        var pc = s.pathconfigs[col];
+        if (val.substr(0,4) == 'http'){
+            return '<img style="height:60px" src="' + val + '"/>' ;
+        }
+        if (val != ''){
+            //return '<img src="{/literal}{$_config.connectors_url}{literal}system/phpthumb.php?w=100&h=100&f=png&ra=1&src=' + val + '" alt="" />';
 
-	,loadData: function(){
-	    var items_string = Ext.get('tv{/literal}{$tv->id}{literal}').dom.value;
+            return '<img src="'+MODx.config.connectors_url+'{/literal}system/phpthumb.php?w=100&h=100&f=png&ra=1&src='+val+'&wctx={$ctx}&basePath='+pc.basePath+'&basePathRelative='+pc.basePathRelative+'&baseUrl='+pc.baseUrl+'&baseUrlRelative='+pc.baseUrlRelative+'{literal}" alt="" />';
+        }
+        return val;
+    }
+    ,renderLimited : function(val, md, rec, row, col, s){
+        var max = 100;
+        var count = val.length;
+        if (count>max){
+            return(val.substring(0, max));
+        }
+        return val;
+    }
+    ,renderPreview : function(val,md,rec){
+        return val;
+    }
+
+    ,loadData: function(){
+        var items_string = Ext.get('tv{/literal}{$tv->id}{literal}').dom.value;
         var items = [];
         try {
             items = Ext.util.JSON.decode(items_string);
         }
         catch (e){
         }
-		this.getStore().sortInfo = null;
-		this.getStore().loadData(items);
-			
-		this.syncSize();
+        this.getStore().sortInfo = null;
+        this.getStore().loadData(items);
+
+        this.syncSize();
         this.setWidth('100%');
     }
-	,addItem: function(btn,e) {
-		var s=this.getStore();
-		this.loadWin(btn,e,s.getCount(),'a');
-	}	
-	,update: function(btn,e) {
+    ,addItem: function(btn,e) {
+        var s=this.getStore();
+        this.loadWin(btn,e,s.getCount(),'a');
+    }
+    ,update: function(btn,e) {
       this.loadWin(btn,e,'0','u');
     }
-	,loadWin: function(btn,e,index,action) {
+    ,loadWin: function(btn,e,index,action) {
         if (action == 'a'){
            var json='{/literal}{$newitem}{literal}';
            var data=Ext.util.JSON.decode(json);
         }else{
-		   var s = this.getStore();
-           var rec = s.getAt(index)            
+           var s = this.getStore();
+           var rec = s.getAt(index)
            var data = rec.data;
            var json = Ext.util.JSON.encode(rec.json);
         }
-		
+
         var win_xtype = 'modx-window-tv-item-update';
-		if (this.windows[win_xtype]){
-			this.windows[win_xtype].fp.autoLoad.params.tv_id='{/literal}{$tv->id}{literal}';
-			this.windows[win_xtype].fp.autoLoad.params.tv_name='{/literal}{$tv->name}{literal}';
-		    this.windows[win_xtype].fp.autoLoad.params.itemid=index;
+        if (this.windows[win_xtype]){
+            this.windows[win_xtype].fp.autoLoad.params.tv_id='{/literal}{$tv->id}{literal}';
+            this.windows[win_xtype].fp.autoLoad.params.tv_name='{/literal}{$tv->name}{literal}';
+            this.windows[win_xtype].fp.autoLoad.params.itemid=index;
             this.windows[win_xtype].fp.autoLoad.params.record_json=json;
-			this.windows[win_xtype].grid=this;
+            this.windows[win_xtype].grid=this;
             this.windows[win_xtype].action=action;
-		}
-		this.loadWindow(btn,e,{
+        }
+        this.loadWindow(btn,e,{
             xtype: win_xtype
             ,record: data
-			,grid: this
+            ,grid: this
             ,action: action
-			,baseParams : {
-				record_json:json,
-			    action: 'mgr/fields',
-				tv_id: '{/literal}{$tv->id}{literal}',
-				tv_name: '{/literal}{$tv->name}{literal}',
-				'class_key': 'modDocument',
-				itemid : index
-			}
+            ,baseParams : {
+                record_json:json,
+                action: 'mgr/fields',
+                tv_id: '{/literal}{$tv->id}{literal}',
+                tv_name: '{/literal}{$tv->name}{literal}',
+                'class_key': 'modDocument',
+                itemid : index
+            }
         });
-    }	
-	,collectItems: function(){
-		var items=[];
-		// read jsons from grid-store-items 
+    }
+    ,collectItems: function(){
+        var items=[];
+        // read jsons from grid-store-items
         var griddata=this.store.data;
-		for(i = 0; i <  griddata.length; i++) {
- 			items.push(griddata.items[i].json);
+        for(i = 0; i <  griddata.length; i++) {
+             items.push(griddata.items[i].json);
         }
         Ext.get('tv{/literal}{$tv->id}{literal}').dom.value = Ext.util.JSON.encode(items);
-		return;						 
+        return;
     }
 });
 Ext.reg('modx-grid-multitvgrid',MODx.grid.multiTVgrid);
@@ -153,9 +152,9 @@ MODx.window.UpdateTvItem = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         title: _('property_update')
-        ,id: 'modx-window-mi-grid-update' 
+        ,id: 'modx-window-mi-grid-update'
         ,width: '1000px'
-		,closeAction: 'hide'
+        ,closeAction: 'hide'
         ,shadow: true
         ,resizable: true
         ,collapsible: true
@@ -174,14 +173,14 @@ MODx.window.UpdateTvItem = function(config) {
             ,handler: this.submit
         }]
         ,record: {}
-		,grid: null
+        ,grid: null
         ,action: 'u'
-		,record_json: ''
+        ,record_json: ''
         ,keys: [{
             key: Ext.EventObject.ENTER
             ,fn: this.submit
             ,scope: this
-        }]		
+        }]
         ,fields: []
     });
     MODx.window.UpdateTvItem.superclass.constructor.call(this,config);
@@ -193,10 +192,10 @@ MODx.window.UpdateTvItem = function(config) {
         success: true
         ,failure: true
         ,beforeSubmit: true
-		,hide:true
-		,show:true
+        ,hide:true
+        ,show:true
     });
-    this._loadForm();	
+    this._loadForm();
 };
 Ext.extend(MODx.window.UpdateTvItem,Ext.Window,{
     submit: function() {
@@ -204,14 +203,14 @@ Ext.extend(MODx.window.UpdateTvItem,Ext.Window,{
         if (this.fp.getForm().isValid()) {
             var s = this.grid.getStore();
             if (this.action == 'u'){
-                var idx = this.baseParams.itemid; 
+                var idx = this.baseParams.itemid;
             }else{
                 /*append record*/
                 var items=Ext.util.JSON.decode('{/literal}{$newitem}{literal}');
-		        s.loadData(items,true);
-                idx=s.getCount()-1;                
+                s.loadData(items,true);
+                idx=s.getCount()-1;
             }
-            
+
             var rec = s.getAt(idx);
             var fields = Ext.util.JSON.decode(v['mulititems_grid_item_fields']);
             var item = {};
@@ -219,17 +218,17 @@ Ext.extend(MODx.window.UpdateTvItem,Ext.Window,{
             if (fields.length>0){
                 for (var i = 0; i < fields.length; i++) {
                     tvid = (fields[i].tv_id);
-                    item[fields[i].field]=v['tv'+tvid+'[]'] || v['tv'+tvid] || '';							
+                    item[fields[i].field]=v['tv'+tvid+'[]'] || v['tv'+tvid] || '';
                     //set defined record-fields to its new value
                     rec.set(fields[i].field,item[fields[i].field])
                 }
                 //we store the item.values to rec.json because perhaps sometimes we can have different fields for each record
                 rec.json=item;
-            }					
+            }
             this.grid.getView().refresh();
             this.grid.collectItems();
-            //this.onDirty();			
-			
+            //this.onDirty();
+
             if (this.fireEvent('success',v)) {
                 this.fp.getForm().reset();
                 this.hide();
@@ -240,13 +239,13 @@ Ext.extend(MODx.window.UpdateTvItem,Ext.Window,{
     },
     _loadForm: function() {
         //if (this.checkIfLoaded(this.config.record || null)) { return false; }
-		this.fp = this.createForm({
+        this.fp = this.createForm({
             url: this.config.url
             ,baseParams: this.config.baseParams || { action: this.config.action || '' }
             ,items: this.config.fields || []
         });
         this.renderForm();
-    }	
+    }
     ,createForm: function(config){
         config = config || {};
         Ext.applyIf(config,{
@@ -254,7 +253,7 @@ Ext.extend(MODx.window.UpdateTvItem,Ext.Window,{
             ,labelWidth: this.config.labelWidth || 100
             ,frame: this.config.formFrame || true
             ,popwindow : this
-			,border: false
+            ,border: false
             ,bodyBorder: false
             ,autoHeight: true
             ,errorReader: MODx.util.JSONReader
@@ -265,9 +264,9 @@ Ext.extend(MODx.window.UpdateTvItem,Ext.Window,{
         return new MODx.panel.MiGridUpdate(config);
     }
     ,renderForm: function() {
-		this.add(this.fp);
-		
-    }		
+        this.add(this.fp);
+
+    }
     ,onShow: function() {
         if (this.fp.isloading) return;
         this.fp.isloading=true;
@@ -282,9 +281,9 @@ MODx.panel.MiGridUpdate = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         id: 'xdbedit-panel-object-{/literal}{$tv->id}{literal}'
-		,title: _('template_variables')
+        ,title: _('template_variables')
         ,url: config.url
-        ,baseParams: config.baseParams	
+        ,baseParams: config.baseParams
         ,class_key: ''
         ,bodyStyle: 'padding: 15px;'
         ,autoSize: true
@@ -293,51 +292,51 @@ MODx.panel.MiGridUpdate = function(config) {
         ,listeners: {
             //'beforeSubmit': {fn:this.beforeSubmit,scope:this},
             'success': {fn:this.success,scope:this}
-			,'load': {fn:this.load,scope:this}
-        }		
+            ,'load': {fn:this.load,scope:this}
+        }
     });
- 	MODx.panel.MiGridUpdate.superclass.constructor.call(this,config);
-	
-	//this.addEvents({ load: true });
+     MODx.panel.MiGridUpdate.superclass.constructor.call(this,config);
+
+    //this.addEvents({ load: true });
 };
 Ext.extend(MODx.panel.MiGridUpdate,MODx.FormPanel,{
     autoload: function(config) {
-		this.isloading=true;
-		var a = {
+        this.isloading=true;
+        var a = {
             url: MODx.config.assets_url+'components/migx/connector.php'
             //url: config.url
-			,method: 'POST'
+            ,method: 'POST'
             ,params: config.baseParams
             ,scripts: true
             ,callback: function() {
-				this.isloading=false;
-				this.isloaded=true;
-				this.fireEvent('load');
+                this.isloading=false;
+                this.isloaded=true;
+                this.fireEvent('load');
                 //MODx.fireEvent('ready');
             }
             ,scope: this
         };
-        return a;        	
+        return a;
     },scope: this
-    
+
     ,
     setup: function() {
 
     }
     ,beforeSubmit: function(o) {
-        //tinyMCE.triggerSave(); 
+        //tinyMCE.triggerSave();
     }
     ,success: function(o) {
-		this.doAutoLoad();
-		var gf = Ext.getCmp('xdbedit-grid-objects');
-		gf.isModified = true;
-		gf.refresh();
+        this.doAutoLoad();
+        var gf = Ext.getCmp('xdbedit-grid-objects');
+        gf.isModified = true;
+        gf.refresh();
      },
-	 load: function() {
-		//MODx.loadRTE();
-		
+     load: function() {
+        //MODx.loadRTE();
+
         if (typeof(Tiny) != 'undefined') {
-		    var s={};
+            var s={};
             if (Tiny.config){
                 s = Tiny.config || {};
                 delete s.assets_path;
@@ -352,20 +351,20 @@ Ext.extend(MODx.panel.MiGridUpdate,MODx.FormPanel,{
                 var z = Ext.state.Manager.get(MODx.siteId + '-tiny');
                 if (z !== false) {
                     delete s.elements;
-                }			
-		    }
-			s.mode = "specific_textareas";
+                }
+            }
+            s.mode = "specific_textareas";
             s.editor_selector = "modx-richtext";
-		    //s.language = "en";// de seems not to work at the moment
-            tinyMCE.init(s);				
-		}
-        
+            //s.language = "en";// de seems not to work at the moment
+            tinyMCE.init(s);
+        }
+
         //this.popwindow.width='1000px';
-		//this.width='1000px';
-		this.syncSize();
-		this.popwindow.syncSize();
-		return '';
-	 }
+        //this.width='1000px';
+        this.syncSize();
+        this.popwindow.syncSize();
+        return '';
+     }
 });
 Ext.reg('xdbedit-panel-object',MODx.panel.MiGridUpdate);
 
@@ -375,10 +374,10 @@ Ext.reg('xdbedit-panel-object',MODx.panel.MiGridUpdate);
             ,tv: '{/literal}{$tv->id}{literal}'
             ,cls:'tv{/literal}{$tv->id}{literal}_items'
             ,id:'tv{/literal}{$tv->id}{literal}_items'
-			,columns:Ext.util.JSON.decode('{/literal}{$columns}{literal}')
-			,pathconfigs:Ext.util.JSON.decode('{/literal}{$pathconfigs}{literal}')
+            ,columns:Ext.util.JSON.decode('{/literal}{$columns}{literal}')
+            ,pathconfigs:Ext.util.JSON.decode('{/literal}{$pathconfigs}{literal}')
             ,fields:Ext.util.JSON.decode('{/literal}{$fields}{literal}')
-            ,width: '97%'			
+            ,width: '97%'
         });
 
 

--- a/core/components/migx/elements/tv/migx_one.tpl
+++ b/core/components/migx/elements/tv/migx_one.tpl
@@ -61,9 +61,9 @@ Ext.extend(MODx.grid.multiTVgrid,MODx.grid.LocalGrid,{
             return '<img style="height:60px" src="' + val + '"/>' ;
         }
         if (val != ''){
-            //return '<img src="{/literal}{$_config.connectors_url}{literal}system/phpthumb.php?w=100&h=100&f=png&ra=1&src=' + val + '" alt="" />';
+            //return '<img src="{/literal}{$_config.connectors_url}{literal}system/phpthumb.php?w=80&h=80&f=png&ra=1&src=' + val + '" alt="" />';
 
-            return '<img src="'+MODx.config.connectors_url+'{/literal}system/phpthumb.php?w=100&h=100&f=png&ra=1&src='+val+'&wctx={$ctx}&basePath='+pc.basePath+'&basePathRelative='+pc.basePathRelative+'&baseUrl='+pc.baseUrl+'&baseUrlRelative='+pc.baseUrlRelative+'{literal}" alt="" />';
+            return '<img src="'+MODx.config.connectors_url+'{/literal}system/phpthumb.php?w=80&h=80&f=png&ra=1&src='+val+'&wctx={$ctx}&basePath='+pc.basePath+'&basePathRelative='+pc.basePathRelative+'&baseUrl='+pc.baseUrl+'&baseUrlRelative='+pc.baseUrlRelative+'{literal}" alt="" />';
         }
         return val;
     }

--- a/core/components/migx/elements/tv/migx_one.tpl
+++ b/core/components/migx/elements/tv/migx_one.tpl
@@ -61,9 +61,9 @@ Ext.extend(MODx.grid.multiTVgrid,MODx.grid.LocalGrid,{
             return '<img style="height:60px" src="' + val + '"/>' ;
         }
         if (val != ''){
-            //return '<img src="{/literal}{$_config.connectors_url}{literal}system/phpthumb.php?w=80&h=80&f=png&ra=1&src=' + val + '" alt="" />';
+            //return '<img src="{/literal}{$_config.connectors_url}{literal}system/phpthumb.php?w=80&h=80&f=png&src=' + val + '" alt="" />';
 
-            return '<img src="'+MODx.config.connectors_url+'{/literal}system/phpthumb.php?w=80&h=80&f=png&ra=1&src='+val+'&wctx={$ctx}&basePath='+pc.basePath+'&basePathRelative='+pc.basePathRelative+'&baseUrl='+pc.baseUrl+'&baseUrlRelative='+pc.baseUrlRelative+'{literal}" alt="" />';
+            return '<img src="'+MODx.config.connectors_url+'{/literal}system/phpthumb.php?w=80&h=80&f=png&src='+val+'&wctx={$ctx}&basePath='+pc.basePath+'&basePathRelative='+pc.basePathRelative+'&baseUrl='+pc.baseUrl+'&baseUrlRelative='+pc.baseUrlRelative+'{literal}" alt="" />';
         }
         return val;
     }


### PR DESCRIPTION
Pretty old bug with transparency in .png for TV. In general, png with white edges is not problem, **but sometimes artifacts appear on the png background**.

Fixed the transparency for .png through adding &f=png. &f=png adds transparency for png, but does not touch jpg.

Also increased the thumbnails to 80, instead of 60.
Fixed tabs in files.

![img2](https://user-images.githubusercontent.com/12523676/63214004-06e27a80-c124-11e9-9b08-10fe6da35cd9.png)