### PR TITLE
Use a textarea instead of an input

### DIFF
--- a/core/components/migx/elements/tv/migx.tpl
+++ b/core/components/migx/elements/tv/migx.tpl
@@ -1,4 +1,4 @@
-<textarea id="tv{$tv->id}" name="tv{$tv->id}" style="display:none" tvtype="{$tv->type}" />{$tv_value|escape}</textarea>
+<textarea id="tv{$tv->id}" name="tv{$tv->id}" style="display:none" tvtype="{$tv->type}">{$tv_value|escape}</textarea>
 
 <div id="tvpanel{$tv->id}" style="width:100%">
 </div>

--- a/core/components/migx/elements/tv/migx.tpl
+++ b/core/components/migx/elements/tv/migx.tpl
@@ -1,4 +1,4 @@
-<input id="tv{$tv->id}" name="tv{$tv->id}" type="hidden" class="textfield" value="{$tv_value|escape}"{$style|default} tvtype="{$tv->type}" />
+<textarea id="tv{$tv->id}" name="tv{$tv->id}" style="display:none" tvtype="{$tv->type}" />{$tv_value|escape}</textarea>
 
 <div id="tvpanel{$tv->id}" style="width:100%">
 </div>


### PR DESCRIPTION
Since the value almost contains quotes, it is not possible to copy/paste the value directly with i.e. the Chrome DevTools. Switching the input to a textarea solves this.
