### PR TITLE
Flatten JSON array so objects are processed properly

### DIFF
--- a/core/components/migx/elements/snippets/migxjsontoplaceholders.snippet.php
+++ b/core/components/migx/elements/snippets/migxjsontoplaceholders.snippet.php
@@ -4,9 +4,12 @@ $prefix = $modx->getOption('prefix',$scriptProperties,'');
 
 //$modx->setPlaceholders($modx->fromJson($value),$prefix,'',true);
 
-$values = $modx->fromJson($value);
+$values = json_decode($value, true);
+
+$it = new RecursiveIteratorIterator(new RecursiveArrayIterator($values));
+
 if (is_array($values)){
-    foreach ($values as $key => $value){
+    foreach ($it as $key => $value){
         $value = $value == null ? '' : $value;
         $modx->setPlaceholder($prefix . $key, $value);
     }


### PR DESCRIPTION
After updating MIGX, it broke the output in a few places for me. Turns out I was using a modified migxJsonToPlaceholders snippet (and forgot about it).

Apparently, the JSON output of migxLoopCollection can't be processed properly if it's a JSON object. So this fails:

```json
[
  {
    "id":"14",
    "createdon":"1603985676",
    "createdby":"1",
    "deleted":"0"
  }
]
```
But this works:
```json
{
  "id":"14",
  "createdon":"1603985676",
  "createdby":"1",
  "deleted":"0"
}
```

After flattening the array first, both options work. See [SO for more info](https://stackoverflow.com/questions/1319903/how-to-flatten-a-multidimensional-array). 