### PR TITLE
Update renderDate

### DIFF
--- a/core/components/migx/configs/grid/grid.renderer.inc.php
+++ b/core/components/migx/configs/grid/grid.renderer.inc.php
@@ -15,7 +15,7 @@ $renderer['this.renderImage'] = "
         if (val !== null) {
             if (val.substr(0,4) == 'http'){
                 return '{$httpimg}' ;
-            }        
+            }
             if (val != ''){
                 return '{$phpthumbimg}';
             }
@@ -33,14 +33,14 @@ $renderer['this.renderImageFromHtml'] = "
         if (val !== null) {
             if (val != ''){
                 var el = document.createElement('div');
-                el.innerHTML = val;               
+                el.innerHTML = val;
                 var img = el.querySelector('img');
-                
+
                 if (img){
                     val = img.getAttribute('src');
                     return '{$phpthumbimg}';
                 }
-                
+
             }
             return val;
         }
@@ -54,7 +54,7 @@ $renderer['this.renderImageFromHtml'] = "
 $renderer['this.renderPlaceholder'] = "
 renderPlaceholder : function(val, md, rec, row, col, s){
          return '[[+'+val+'.'+rec.json.MIGX_id+']]';
-        
+
 	}
 ";
 
@@ -62,7 +62,7 @@ $renderer['this.renderFirst'] = "
 renderFirst : function(val, md, rec, row, col, s){
 		val = val.split(':');
         return val[0];
-	}        
+	}
 ";
 
 $renderer['this.renderLimited'] = "
@@ -71,16 +71,16 @@ renderLimited : function(val, md, rec, row, col, s){
         var count = val.length;
 		if (count>max){
             return(val.substring(0, max));
-		}        
+		}
 		return val;
-	}    
+	}
 ";
 
 $img = '<img src="{0}" alt="{1}" title="{2}">';
 $renderer['this.renderCrossTick'] = "
 renderCrossTick : function(val, md, rec, row, col, s) {
     var renderImage, altText, handler, classname;
-    
+
     switch (val) {
         case 0:
         case '0':
@@ -152,7 +152,7 @@ renderSwitchStatusOptions : function(val, md, rec, row, col, s) {
 ";
 
 $tpl = '{6} <a href="#" ><img class="controlBtn btn_selectpos {4} selectpos" src="'.$base_url.$assets_url.'components/migx/style/images/arrow_updown.png" alt="select" title="select position"></a>';
-$tpl_active = '{6} '; 
+$tpl_active = '{6} ';
 $tpl_active .= '<a href="#" ><img class="controlBtn btn_before {4} {5}:before" src="'.$base_url.$assets_url.'components/migx/style/images/arrow_up.png" alt="before" title="move before"></a>';
 $tpl_active .= '<a href="#" ><img class="controlBtn btn_cancel {4} cancel" src="'.$base_url.$assets_url.'components/migx/style/images/cancel.png" alt="cancel" title="cancel"></a>';
 $tpl_active .= '<a href="#" ><img class="controlBtn btn_after {4} {5}:after" src="'.$base_url.$assets_url.'components/migx/style/images/arrow_down.png" alt="after" title="move after"></a>';
@@ -169,10 +169,10 @@ renderPositionSelector : function(val, md, rec, row, col, s) {
     }
     value = val;
     classname = 'test';
-    
+
     if (this.isPosSelecting){
         altText = 'before' ;
-        return String.format('{$tpl_active}', renderImage, altText, altText, classname, handler, column.dataIndex, value);            
+        return String.format('{$tpl_active}', renderImage, altText, altText, classname, handler, column.dataIndex, value);
     }
     else{
         altText = 'select' ;
@@ -185,7 +185,7 @@ renderPositionSelector : function(val, md, rec, row, col, s) {
 $renderer['this.renderRowActions'] = "
 	dummy:function(v,md,rec) {
         // this function is fixed in the grid
-	} 
+	}
 ";
 
 $renderer['this.renderChunk'] = "
@@ -198,13 +198,18 @@ renderChunk : function(val, md, rec, row, col, s) {
 $renderer['ImagePlus.MIGX_Renderer'] = "
 	dummyImagePlus:function(v,md,rec) {
         // this function is included with the ImagePlus - TV
-	} 
+	}
 ";
 
 $renderer['this.renderDate'] = "
 renderDate : function(val, md, rec, row, col, s) {
     var date;
 	if (val && val != '') {
+        // Cast val to number when unix timestamp is passed in as a string
+        var tsRegex = /^-?\d{1,10}$/;
+        if (typeof val == 'string' && tsRegex.test(val)) {
+            val = parseInt(val);
+        }
         if (typeof val == 'number') {
             date = new Date(val*1000);
         } else {
@@ -212,10 +217,10 @@ renderDate : function(val, md, rec, row, col, s) {
         }
         if (typeof(date) != 'undefined' ){
 		    return String.format('{0}', date.format(MODx.config.manager_date_format+' '+MODx.config.manager_time_format));
-        }    
-	} 
+        }
+	}
 	return '';
-	
+
 }
 ";
 


### PR DESCRIPTION
CONTEXT:
Column rendering of dates in migxdb

PROBLEM:
When a unix timestamp is passed into the renderDate function, it's data type may be _string_ instead of _number_ (even though the database's column type is _int_). In this case, renderDate currently fails to recognize the data as a numeric timestamp and returns an empty string.

SOLUTION:
Adds a basic regex test for unix timestamp and explicitly casts a match to number (via parseInt) to ensure numeric string timestamps are rendered properly.