### PR TITLE
Fix check_resid_tv behavior

### DIFF
--- a/core/components/migx/model/migx/migx.class.php
+++ b/core/components/migx/model/migx/migx.class.php
@@ -1748,11 +1748,9 @@ class Migx {
         if ($resource_id) {
             $check_resid = $this->modx->getOption('check_resid', $config);
             if ($check_resid == '@TV' && $resource = $this->modx->getObject('modResource', $resource_id)) {
-                if ($check = $resource->getTvValue($config['check_resid_TV'])) {
-                    $check_resid = $check;
-                }
+                $check = $resource->getTvValue($config['check_resid_TV']);
             }
-            if (!empty($check_resid)) {
+            if (!empty($check)) {
                 //$c->where("CONCAT('||',resource_ids,'||') LIKE '%||{$resource_id}||%'", xPDOQuery::SQL_AND);
                 return true;
             }


### PR DESCRIPTION
Hi,

I found that `check_resid_tv` option was not working as expected.

## Expected behavior
I expected that when `check_resid` is set to `@TV` and `check_resid_TV` value is falsy (0 or empty), migxdbTV grid will show all existing items without checking if it is connected to current resource id.

## Problem
In my project with such setup, function `checkForConnectedResource` was always returning `true`, and page with falsy check_resid_TV showed none items.
I found out that in old code `$check_resid` is never falsy, because it can be set to (falsy) `$check` only if `$check` is truthy.

## Solution
After proposed changes migxdb grid in my project works as expected:
- Shows all items when check_resid_tv is falsy in current resource
- Show only items, that are connected by resource_id, when check_resid_tv is truthy
