### PR TITLE
Added correct display of MIGX field placeholders in edit window tooltips

### DIFF
--- a/core/components/migx/templates/mgr/fields.tpl
+++ b/core/components/migx/templates/mgr/fields.tpl
@@ -2,7 +2,7 @@
 {$error|default}
 {if $formcaption != ''}
     <h2>{$formcaption}</h2>
-{/if} 
+{/if}
 
 <input type="hidden" class="mulititems_grid_item_fields" name="mulititems_grid_item_fields" value='{$fields|escape}' />
 <input type="hidden" class="tvmigxid" name="tvmigxid" value='{$migxid|default}' />
@@ -15,13 +15,13 @@
                     <div class="x-form-item x-tab-item {cycle values=",alt"} modx-tv" id="tvFormname-tr">
                         <label for="tvFormname" class="modx-tv-label">
                             <span class="modx-tv-caption" id="tvFormname-caption">{$multiple_formtabs_label}</span>
-                            <span class="modx-tv-reset" ></span> 
+                            <span class="modx-tv-reset" ></span>
                             {if $tv->descriptionX}<span class="modx-tv-description">{$tv->descriptionX}</span>{/if}
                         </label>
                         <div class="x-form-element modx-tv-form-element" style="padding-left: 200px;">
                             <select id="tvFormname" name="tvFormname">
                             {foreach from=$formnames item=item}
-	                            <option value="{$item.value}" {if $item.selected} selected="selected"{/if}>{$item.text}</option>
+                                <option value="{$item.value}" {if $item.selected} selected="selected"{/if}>{$item.text}</option>
                             {/foreach}
                             </select>
                         </div>
@@ -44,33 +44,33 @@
                             ,typeAhead: false
                             ,forceSelection: false
                             ,msgTarget: 'under'
-                            ,listeners: { 
-		                    'select': {fn:this.selectForm,scope:this}
-		                }});
+                            ,listeners: {
+                            'select': {fn:this.selectForm,scope:this}
+                        }});
                         MODx.combo.FormnameDropdown.superclass.constructor.call(this,config);
                         //this.config = config;
                         //return this;
                     };
                     Ext.extend(MODx.combo.FormnameDropdown,Ext.form.ComboBox,{
-	                    selectForm: function() {
-		                    var win = Ext.getCmp('{/literal}modx-window-mi-grid-update-{$win_id}{literal}');
+                        selectForm: function() {
+                            var win = Ext.getCmp('{/literal}modx-window-mi-grid-update-{$win_id}{literal}');
                             //win.fp.autoLoad.params.record_json=this.baseParams.record_json;
                             win.switchForm();
-		                    //panel.autoLoad.params['context']=this.getValue();
-		                    //panel.doAutoLoad();
-		                    //MODx.fireResourceFormChange();
-	                    }
-                    }); 
+                            //panel.autoLoad.params['context']=this.getValue();
+                            //panel.doAutoLoad();
+                            //MODx.fireResourceFormChange();
+                        }
+                    });
                     Ext.reg('modx-combo-formnamedropdown',MODx.combo.FormnameDropdown);
                     MODx.load({
                         xtype: 'modx-combo-formnamedropdown'
                     });
                     {/literal}
                     // ]]>
-                    </script>    
+                    </script>
                 {/if}
             {/if}
-            
+
             {if count($categories) < 2 OR ($smarty.foreach.cat.first AND $category.print_before_tabs)}
             {assign var="opentabs" value="0"}
             {/if}
@@ -80,7 +80,7 @@
             {/if}
             {if count($categories) > 1 AND $smarty.foreach.cat.first AND $category.print_before_tabs}
             {assign var="opentabs" value="1"}
-            {/if}            
+            {/if}
             {if count($categories) < 2 OR ($smarty.foreach.cat.first AND $category.print_before_tabs)}
             <div id="modx-tv-tab{$category.id}" >
             {else}
@@ -90,22 +90,22 @@
                 <div class="layout" style="width:100%;clear:both;float:left;{$layout.style|default}">
                     {if $layout.caption != ''}
                         <h3>{$layout.caption}</h3>
-                    {/if}                    
+                    {/if}
                     {foreach from=$layout.columns item=layoutcolumn name='layoutcolumn'}
                         <div class="column" style="{if !$smarty.foreach.layoutcolumn.last}padding-right: 10px;{/if}width:{$layoutcolumn.width};min-width:{$layoutcolumn.minwidth};float:left;{$layoutcolumn.style}">
                             {if $layoutcolumn.caption != ''}
                                 <h4>{$layoutcolumn.caption}</h4>
-                            {/if}                              
+                            {/if}
                             {foreach from=$layoutcolumn.tvs item=tv name='tv'}
                                 {if $tv->type EQ "description_is_code"}
                                     {$tv->get('formElement')}
                                 {elseif $tv->type NEQ "hidden"}
                                     <div class="x-form-item x-tab-item {cycle values=",alt"} modx-tv" id="tv{$tv->id}-tr" style="width: calc(100% - 5px); padding:0 !important;{if $tv->display EQ "none"}display:none;{/if} ">
                                         <label for="tv{$tv->id}" class="x-form-item-label modx-tv-label" style="width: auto;">
-                                            <div class="modx-tv-label-title"> 
+                                            <div class="modx-tv-label-title">
                                                 {if $showCheckbox|default}<input type="checkbox" name="tv{$tv->id}-checkbox" class="modx-tv-checkbox" value="1" />{/if}
                                                 <span class="modx-tv-caption" id="tv{$tv->id}-caption">{$tv->caption}</span>
-                                            </div>    
+                                            </div>
                                             <a class="modx-tv-reset" id="modx-tv-reset-{$tv->id}" onclick="MODx.resetTV({$tv->id});" title="{$_lang.set_to_default}"></a>
                                             {if $tv->description}<span class="modx-tv-label-description">{$tv->description}</span>{/if}
                                         </label>
@@ -123,18 +123,18 @@
                                 {/if}
                             {/foreach}<!-- $layoutcolumn.tvs  -->
                         </div> <!-- column  -->
-                    {/foreach}<!-- $layout.columns  -->    
+                    {/foreach}<!-- $layout.columns  -->
                 </div> <!-- layout  -->
             {/foreach}<!-- $category.layouts  -->
             </div>
             {if $smarty.foreach.cat.first AND $category.print_before_tabs}
                 <br class="clear" />
-            {/if}            
+            {/if}
             {if count($categories) > 1 AND ($smarty.foreach.cat.last)}
-            </div>    
-            {/if}         
+            </div>
+            {/if}
         {/if}
-       
+
     {/foreach}<!-- $categories  -->
 
 
@@ -142,7 +142,7 @@
 {literal}
 <script type="text/javascript">
 // <![CDATA[
-Ext.onReady(function() {    
+Ext.onReady(function() {
     var tabs = MODx.load({
         xtype: 'modx-tabs'
         ,applyTo: '{/literal}modx-window-mi-grid-update-{$win_id}-tabs{literal}'
@@ -157,10 +157,10 @@ Ext.onReady(function() {
         }
         ,deferredRender: false
     });
-    var win = Ext.getCmp('{/literal}modx-window-mi-grid-update-{$win_id}{literal}');    
+    var win = Ext.getCmp('{/literal}modx-window-mi-grid-update-{$win_id}{literal}');
     win.tabs = tabs;
-    
-});    
+
+});
 // ]]>
 </script>
 {/literal}

--- a/core/components/migx/templates/mgr/fields.tpl
+++ b/core/components/migx/templates/mgr/fields.tpl
@@ -116,7 +116,7 @@
                                             {$tv->get('formElement')}
                                         </div>
                                      </div>
-                                    <script type="text/javascript">{literal}Ext.onReady(function() { new Ext.ToolTip({{/literal}target: 'tv{$tv->id}-caption',html: '[[*{$tv->name}]]'{literal}});});{/literal}</script>
+                                    <script type="text/javascript">var migx_fields = {$fields};var migx_field = migx_fields.find(item => item.tv_id == '{$tv->id}');{literal}Ext.onReady(function() { new Ext.ToolTip({{/literal}target: 'tv{$tv->id}-caption',html: '[[+'+migx_field.field+']]'{literal}});});{/literal}</script>
                                 {else}
                                     <input type="hidden" id="tvdef{$tv->id}" value="{$tv->default_text|escape}" />
                                     {$tv->get('formElement')}


### PR DESCRIPTION
### What does it do?
Added correct display of MIGX field placeholders in edit window:
- Now the name of the MIGX-field is displayed, which can already be used in a chunk with `getImageList`, for example.
- Because MIGX-field cannot be called separately, i changed the tooltips output from `[[*field-name]]` to `[[+field-name]]`.

Before:
![migx-window-ph-1](https://user-images.githubusercontent.com/12523676/122412890-040e7600-cf97-11eb-800e-afaa4e2ad157.gif)

After:
![migx-window-ph-2](https://user-images.githubusercontent.com/12523676/122412895-053fa300-cf97-11eb-8029-b28a6ddb987d.gif)

### Why is it needed?
UX improvement.

### Related issue(s)/PR(s)
In my opinion there was issue, but I did not find it.