### PR TITLE
Fix deprecation warning

### DIFF
--- a/core/components/migx/model/migx/migx.class.php
+++ b/core/components/migx/model/migx/migx.class.php
@@ -1760,7 +1760,7 @@ class Migx {
         return $fields;
     }
 
-    function checkForConnectedResource($resource_id = false, &$config) {
+    function checkForConnectedResource($resource_id = false, &$config = []) {
         if ($resource_id) {
             $check_resid = $this->modx->getOption('check_resid', $config);
             if ($check_resid == '@TV' && $resource = $this->modx->getObject('modResource', $resource_id)) {


### PR DESCRIPTION
Fixes deprecation warning:
Deprecated:  Optional parameter $resource_id declared before required parameter $config is implicitly treated as a required parameter in /core/components/migx/model/migx/migx.class.php  on line  1763

Tested with:
MODX 3
PHP 8.1

Related issue:
https://github.com/Bruno17/MIGX/issues/361