### PR TITLE
Fix deprecation warning

### DIFF
--- a/core/components/migx/model/migx/migx.class.php
+++ b/core/components/migx/model/migx/migx.class.php
@@ -2196,7 +2196,7 @@ class Migx {
         return true;
     }
 
-    function tvFilters($tvFilters = '', &$criteria) {
+    function tvFilters($tvFilters = '', &$criteria = null) {
 
         //tvFilter::categories=inArray=[[+category]]
 


### PR DESCRIPTION
Fixes deprecation warning:
Deprecated:  Optional parameter $tvFilters declared before required parameter $criteria is implicitly treated as a required parameter in /core/components/migx/model/migx/migx.class.php on line 2199

Tested with:
MODX 3
PHP 8.1

Related issue:
https://github.com/Bruno17/MIGX/issues/361