### PR TITLE
Fix alias in getSelectColumns when using MODX3 classes

### DIFF
--- a/core/components/migx/processors/mgr/default/getlist.php
+++ b/core/components/migx/processors/mgr/default/getlist.php
@@ -113,7 +113,8 @@ $where = $chunk->process($scriptProperties);
 
 $c = $xpdo->newQuery($classname);
 
-$c->select($xpdo->getSelectColumns($classname, $classname, '', $selectfields));
+$shortClassName = end(explode('\\', $classname));
+$c->select($xpdo->getSelectColumns($classname, $shortClassName, '', $selectfields));
 if (!empty($specialfields)) {
     $c->select($specialfields);
 }


### PR DESCRIPTION
This fixes the alias in getSelectColumns when using MODX3 classes.

Before the query would result in:
```php
SELECT `\Sterc\Site\Model\Logo`.`id`, `\Sterc\Site\Model\Logo`.`title`, `\Sterc\Site\Model\Logo`.`url`, `\Sterc\Site\Model\Logo`.`logo`, `\Sterc\Site\Model\Logo`.`default`, `\Sterc\Site\Model\Logo`.`active` FROM `6sn7rm_sterc_logo` AS `Logo` ORDER BY id ASC LIMIT 10 
```

After the fix it results in:
```php
SELECT `Logo`.`id`, `Logo`.`title`, `Logo`.`url`, `Logo`.`logo`, `Logo`.`default`, `Logo`.`active` FROM `6sn7rm_sterc_logo` AS `Logo` ORDER BY id ASC LIMIT 10 
```