### PR TITLE
Fix MODX 3 class compatibility

### DIFF
--- a/core/components/migx/processors/mgr/default/fields.php
+++ b/core/components/migx/processors/mgr/default/fields.php
@@ -68,11 +68,13 @@ if (empty($scriptProperties['object_id']) || $scriptProperties['object_id'] == '
     }
 
 } else {
+    $shortClassName = end(explode('\\', $classname));
+    
     $c = $xpdo->newQuery($classname, $scriptProperties['object_id']);
     $pk = $xpdo->getPK($classname);
     $c->select('
-        `' . $classname . '`.*,
-    	`' . $classname . '`.`' . $pk . '` AS `object_id`
+        `' . $shortClassName . '`.*,
+    	`' . $shortClassName . '`.`' . $pk . '` AS `object_id`
     ');
     if (!empty($joinalias)) {
         $c->leftjoin($joinclass, $joinalias);


### PR DESCRIPTION
This fixes MODX 3 class compatability.

Before the query would result in:

```
SELECT `\Sterc\Site\Model\Logo`.`id`, `\Sterc\Site\Model\Logo`.`title`, `\Sterc\Site\Model\Logo`.`url`, `\Sterc\Site\Model\Logo`.`logo`, `\Sterc\Site\Model\Logo`.`default`, `\Sterc\Site\Model\Logo`.`active` FROM `6sn7rm_sterc_logo` AS `Logo` ORDER BY id ASC LIMIT 10 
```
After the fix it results in:
```
SELECT `Logo`.`id`, `Logo`.`title`, `Logo`.`url`, `Logo`.`logo`, `Logo`.`default`, `Logo`.`active` FROM `6sn7rm_sterc_logo` AS `Logo` ORDER BY id ASC LIMIT 10 ```