### PR TITLE
Allow null for datetime fields

### DIFF
--- a/core/components/migx/model/schema/migx.mysql.schema.xml
+++ b/core/components/migx/model/schema/migx.mysql.schema.xml
@@ -72,14 +72,14 @@
         <field key="rank" dbtype="int" precision="10" phptype="integer" null="false" default="0" />
         
         <field key="createdby" dbtype="int" precision="10" phptype="integer" null="false" default="0" />	
-    	<field key="createdon" dbtype="datetime" phptype="datetime" null="false" />
+    	<field key="createdon" dbtype="datetime" phptype="datetime" null="true" />
 		<field key="editedby" dbtype="int" precision="10" phptype="integer" null="false" default="0" />
-		<field key="editedon" dbtype="datetime" phptype="datetime" null="false" />
+		<field key="editedon" dbtype="datetime" phptype="datetime" null="true" />
 		<field key="deleted" dbtype="tinyint" precision="1" attributes="unsigned" phptype="integer" null="false" default="0" />
-		<field key="deletedon" dbtype="datetime" phptype="datetime" null="false" />
+		<field key="deletedon" dbtype="datetime" phptype="datetime" null="true" />
 		<field key="deletedby" dbtype="int" precision="10" phptype="integer" null="false" default="0" />
         <field key="published" dbtype="tinyint" precision="1" attributes="unsigned" phptype="integer" null="false" default="0" />        
-		<field key="publishedon" dbtype="datetime" phptype="datetime" null="false" />
+		<field key="publishedon" dbtype="datetime" phptype="datetime" null="true" />
 		<field key="publishedby" dbtype="int" precision="10" phptype="integer" null="false" default="0" />
         
         <aggregate alias="Config" class="migxConfig" local="config_id" foreign="id" cardinality="one" owner="foreign" /> 
@@ -91,14 +91,14 @@
         <field key="content" dbtype="text" phptype="string" null="false" default="" />
 	
         <field key="createdby" dbtype="int" precision="10" phptype="integer" null="false" default="0" />	
-    	<field key="createdon" dbtype="datetime" phptype="datetime" null="false" />
+    	<field key="createdon" dbtype="datetime" phptype="datetime" null="true" />
 		<field key="editedby" dbtype="int" precision="10" phptype="integer" null="false" default="0" />
-		<field key="editedon" dbtype="datetime" phptype="datetime" null="false" />
+		<field key="editedon" dbtype="datetime" phptype="datetime" null="true" />
 		<field key="deleted" dbtype="tinyint" precision="1" attributes="unsigned" phptype="integer" null="false" default="0" />
-		<field key="deletedon" dbtype="datetime" phptype="datetime" null="false" />
+		<field key="deletedon" dbtype="datetime" phptype="datetime" null="true" />
 		<field key="deletedby" dbtype="int" precision="10" phptype="integer" null="false" default="0" />
         <field key="published" dbtype="tinyint" precision="1" attributes="unsigned" phptype="integer" null="false" default="0" />        
-		<field key="publishedon" dbtype="datetime" phptype="datetime" null="false" />
+		<field key="publishedon" dbtype="datetime" phptype="datetime" null="true" />
 		<field key="publishedby" dbtype="int" precision="10" phptype="integer" null="false" default="0" /> 
         
         <aggregate alias="Configs" class="migxConfigElement" local="id" foreign="element_id" cardinality="many" owner="local" />        


### PR DESCRIPTION
And avoid such errors
```
Error adding field migxConfig->permissions: Array ( [0] => 22007 [1] => 1292 [2] => Incorrect datetime value: '0000-00-00 00:00:00' for column 'publishedon' at row 1 )
```