### PR TITLE
Enable basic Package Manager functionality for MODX 3

### DIFF
--- a/core/components/migx/model/migx/migxpackagemanager.class.php
+++ b/core/components/migx/model/migx/migxpackagemanager.class.php
@@ -1,6 +1,12 @@
 <?php
+$isMODX3 = $this->modx->getVersionData()['version'] >= 3;
+if ($isMODX3) {
+    abstract class DynamicBaseMigxPackageManager extends \xPDO\Om\mysql\xPDOGenerator {}
+} else {
+    abstract class DynamicBaseMigxPackageManager extends xPDOGenerator_mysql {}
+}
 
-class MigxPackageManager extends xPDOGenerator_mysql {
+class MigxPackageManager extends DynamicBaseMigxPackageManager {
     function __construct(modX & $modx, array $config = array()) {
         $this->modx = &$modx;
         $this->maps = array();
@@ -9,11 +15,20 @@ class MigxPackageManager extends xPDOGenerator_mysql {
         $this->config = array_merge($defaultconfig, $config);
 
         $this->manager = $this->modx->getManager();
-
+        $this->isMODX3 = $this->modx->getVersionData()['version'] >= 3;
     }
 
     public function compile($path = '') {
-        $this->packageClasses = $this->classes;
+        if ($this->isMODX3) {
+            $this->packageClasses = array();
+            //Add package name (namespace) to the class name
+            $packagename = $this->model['package'];
+            foreach ($this->classes as $class => $value) {
+                $this->packageClasses[$packagename . '\\' . $class] = $value;
+            }
+        } else {
+            $this->packageClasses = $this->classes;
+        }
         return true;
     }
 


### PR DESCRIPTION
Adds some changes, so that the basic functionality of the Package Manager works in MODX 3.

---

With a schema like this
```
<?xml version="1.0" encoding="UTF-8"?>
<model package="mypackage" baseClass="xPDO\Om\xPDOObject" platform="mysql" defaultEngine="InnoDB" version="3.0">
	<object class="Myclass" table="mypackage_myclass" extends="xPDO\Om\xPDOSimpleObject">
		<field key="name" dbtype="varchar" precision="150" phptype="string" null="false" default="" />
	</object>
</model>
```
and the buttons "Create Package", "save Schema", "parse Schema" and "create Tables", it is then possible to create a config with Package = `mypackage` and  Classname = `mypackage\Myclass` in the "MIGXdb-Settings" tab and successfully add/edit data in a CMP (if the PRs #394 and #395 are applied as well).