### PR TITLE
Add ID of mediasource for renderChunk

### DIFF
--- a/core/components/migx/model/migx/migx.class.php
+++ b/core/components/migx/model/migx/migx.class.php
@@ -1663,6 +1663,7 @@ class Migx {
                             $row['_this.value'] = $value;
                             $properties = $row;
                             $properties['_request'] = $_REQUEST;
+                            $properties['_media_source_id'] = $this->config['media_source_id'];
                             $renderchunktpl = $this->modx->getOption('_renderchunktpl', $option, '');
                             if (!empty($renderchunktpl)) {
                                 $row[$column] = $this->renderChunk($renderchunktpl, $properties, false);


### PR DESCRIPTION
This is necessary so that when rendering a chunk, you can find the source path for a photo or file. Now the source id is specified and in the render it remains to add a snippet of getting a path for a specific task. 
The problem of constant rendering of photos is also solved. Because render Image (if there are many and different photos) loads the server and a 508 or 504 error pops up. The MIGX table with the photo is also twitching then refresh some data in tables, but if you add this little line of code, you can render as you like.

It add placeholder **_media_source_id** to the renderOptions for each item field.

Partial solution of the problem:
#372 