### PR TITLE
Avoid addPackage error log messages for MODX 3 packages

### DIFF
--- a/core/components/migx/model/migx/migx.class.php
+++ b/core/components/migx/model/migx/migx.class.php
@@ -145,7 +145,9 @@ class Migx {
                 $xpdo = &$this->modx;
             }
 
-            $xpdo->addPackage($packageName, $modelpath, $prefix);
+            if (is_dir($modelpath)) {
+                $xpdo->addPackage($packageName, $modelpath, $prefix);
+            }
         } else {
             $xpdo = &$this->modx;
         }


### PR DESCRIPTION
For MODX 3 packages, the code constantly creates error messages in the log `"Path specified for package {$pkg} is not a valid or accessible directory: {$path}"`, because the path was changed from `model/` to `src/Model/`.

This can be avoided by leaving `packageName` empty in the configuration, but for custom processors/renderers/etc. to work, the package name has to be filled in.