### PR TITLE
Fix typo in update processor

### DIFF
--- a/core/components/migx/processors/mgr/default/update.php
+++ b/core/components/migx/processors/mgr/default/update.php
@@ -318,7 +318,7 @@ switch ($task) {
         }
         if (empty($postvalues['ow_publishedon'])) {
             $postvalues['publishedon'] = $tempvalues['publishedon'];
-            if ($tempvalues['pubishedon'] < 0){
+            if ($tempvalues['publishedon'] < 0){
                 unset($postvalues['publishedon']);
             }            
         }


### PR DESCRIPTION
Creates a PHP warning in PHP 8 as reported here:
https://community.modx.com/t/migxdb-and-modx3/6686