### PR TITLE
Remove PHP 8 warnings

### DIFF
--- a/core/components/migx/model/migx/migx.class.php
+++ b/core/components/migx/model/migx/migx.class.php
@@ -1673,7 +1673,7 @@ class Migx {
                             $row['_this.value'] = $value;
                             $properties = $row;
                             $properties['_request'] = $_REQUEST;
-                            $properties['_media_source_id'] = $this->config['media_source_id'];
+                            $properties['_media_source_id'] = isset($this->config['media_source_id']) ? $this->config['media_source_id'] : 0;
                             $renderchunktpl = $this->modx->getOption('_renderchunktpl', $option, '');
                             if (!empty($renderchunktpl)) {
                                 $row[$column] = $this->renderChunk($renderchunktpl, $properties, false);

--- a/core/components/migx/processors/mgr/default/update.php
+++ b/core/components/migx/processors/mgr/default/update.php
@@ -101,10 +101,6 @@ $classname = $config['classname'];
 $auto_create_tables = isset($config['auto_create_tables']) ? $config['auto_create_tables'] : true;
 $modx->setOption(xPDO::OPT_AUTO_CREATE_TABLES, $auto_create_tables);
 
-if ($modx->lexicon) {
-    $modx->lexicon->load($packageName . ':default');
-}
-
 $co_id = $modx->getOption('co_id', $scriptProperties, '');
 
 if (isset($scriptProperties['data'])) {


### PR DESCRIPTION
**Update processor**

If no 'packageName' is defined (e.g. for MODX 3 classes), the update processor generates a `Undefined variable $packageName` warning.
If there is a 'packageName', the lexicon gets already loaded a few lines above the deleted code.

---

**this.renderChunk renderer**

If the 'this.renderChunk' renderer is used for a grid column, the code generates a `Undefined array key "media_source_id"` warning.
See issue #416

This is probably not the best way to fix this issue as `$this->config['media_source_id']` seems to never exist.
Maybe `$this->customconfigs['media_source_id']` should be used instead. Or more elaborate code like:
```
if (isset($this->customconfigs['media_source_id'])) {
    $properties['_media_source_id'] = $this->customconfigs['media_source_id'];
} else {
    $properties['_media_source_id'] = is_object($this->source) ? $this->source->id : $this->getDefaultSource('id');
}
```