### PR TITLE
Fix dragdrop for MODX 3 CMP

### DIFF
--- a/core/components/migx/model/migx/migx.class.php
+++ b/core/components/migx/model/migx/migx.class.php
@@ -2755,7 +2755,7 @@ class Migx {
             //$parent = $workingobject->get('parent');
             $c = $xpdo->newQuery($classname);
             //$c->where(array('deleted'=>0 , 'parent'=>$parent));
-            $c->select($xpdo->getSelectColumns($classname, $classname));
+            $c->select($xpdo->getSelectColumns($classname, $c->getAlias()));
 
             if (!empty($joinalias)) {
                 /*


### PR DESCRIPTION
Removes the namespace of the MODX 3 class to get a valid SQL query.

Related forum topic:
https://community.modx.com/t/migx-php-compatibility/7735