### PR TITLE
Added output of lexicons for empty items

### DIFF
--- a/core/components/migx/templates/mgr/grids/default.grid.tpl
+++ b/core/components/migx/templates/mgr/grids/default.grid.tpl
@@ -51,6 +51,7 @@ MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal} = function(config) {
     sm: this.sm,
 	viewConfig: {
         emptyText: '[[%migx.noitems]]',
+        deferEmptyText: false,
         forceFit: true,
 		autoFill: true
     },

--- a/core/components/migx/templates/mgr/grids/default.grid.tpl
+++ b/core/components/migx/templates/mgr/grids/default.grid.tpl
@@ -2,7 +2,7 @@
 
 MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal} = function(config) {
     config = config || {};
-	//console.log(config);
+    //console.log(config);
     this.sm = new Ext.grid.CheckboxSelectionModel();
 
     // define grid columns in a separate variable
@@ -17,10 +17,10 @@ MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal} = function(config) {
     {/if}
     {literal}
     if (pageSize != ''){
-        config.pageSize=parseInt(pageSize); 
+        config.pageSize=parseInt(pageSize);
     }
-   
-	for(i = 0; i <  config.columns.length; i++) {
+
+    for(i = 0; i <  config.columns.length; i++) {
         renderer = config.columns[i]['renderer'];
         if (typeof renderer != 'undefined'){
             config.columns[i]['renderer'] = {fn:eval(renderer),scope:this};
@@ -31,50 +31,50 @@ MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal} = function(config) {
             if (this[editor]){
                 config.columns[i]['editor'] = this[editor](config.columns[i]);
             }
-        }         
+        }
         cols.push(config.columns[i]);
         pc.push(config.pathconfigs[i]);
     }
-    config.pathconfigs = pc; 
-    config.columns=cols;    
+    config.pathconfigs = pc;
+    config.columns=cols;
     Ext.applyIf(config,{
-	autoHeight: true,
+    autoHeight: true,
     collapsible: true,
-	resizable: true,
+    resizable: true,
     loadMask: true,
     paging: true,
     pageSize: 10,
     autosave: false,
     remoteSort: true,
     primaryKey: 'id',
-    isModified : false,    
+    isModified: false,
     sm: this.sm,
-	viewConfig: {
+    viewConfig: {
         emptyText: '[[%migx.noitems]]',
         deferEmptyText: false,
         forceFit: true,
-		autoFill: true
+        autoFill: true
     },
     url : config.url,
-    baseParams: { 
+    baseParams: {
         action: 'mgr/migxdb/getlist',
         configs: config.configs,
         reqTempParams:'{/literal}{$reqTempParams}{literal}',
-        reqConfigs:'{/literal}{$reqConfigs}{literal}', 
+        reqConfigs:'{/literal}{$reqConfigs}{literal}',
         resource_id: config.resource_id,
         object_id: config.object_id,
         'HTTP_MODAUTH': config.auth
     },
-    fields: [],    
+    fields: [],
     columns: [], // define grid columns in a separate variable
-    tbar: [{/literal}{$customconfigs.tbar}{literal}]        
+    tbar: [{/literal}{$customconfigs.tbar}{literal}]
     });
-	
+
     MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal}.superclass.constructor.call(this,config)
     this._makeTemplates();
     this.setDefaultFilters();
     this.getStore().pathconfigs=config.pathconfigs;
-    this.on('click', this.onClickGrid, this);   
+    this.on('click', this.onClickGrid, this);
 
 };
 Ext.extend(MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal},MODx.grid.Grid,{
@@ -83,19 +83,19 @@ Ext.extend(MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal},MODx.grid.Grid,{
     }
     ,_makeTemplates: function() {
         this.tplRowActions = new Ext.XTemplate('<tpl for="."><div class="migx-actions-column">'
-										    +'<h3 class="main-column">{column_value}</h3>'
-												+'<tpl if="column_actions">'
-													+'<ul class="actions">'
+                                            +'<h3 class="main-column">{column_value}</h3>'
+                                                +'<tpl if="column_actions">'
+                                                    +'<ul class="actions">'
                                                         +'<tpl for="column_actions">'
-                                                            +'<tpl if="typeof (className) != '+"'undefined'"+'">'   
-														    +'<li><a href="#" class="controlBtn {className} {handler}">{text}</a></li>'
+                                                            +'<tpl if="typeof (className) != '+"'undefined'"+'">'
+                                                            +'<li><a href="#" class="controlBtn {className} {handler}">{text}</a></li>'
                                                           +'</tpl>'
-													    +'</tpl>'
+                                                        +'</tpl>'
                                                     +'</ul>'
-												+'</tpl>'
-											+'</div></tpl>',{
-			compiled: true
-		});
+                                                +'</tpl>'
+                                            +'</div></tpl>',{
+            compiled: true
+        });
     }
     ,setDefaultFilters: function(){
         var filterDefaults = Ext.util.JSON.decode('{/literal}{$filterDefaults}{literal}');
@@ -108,17 +108,17 @@ Ext.extend(MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal},MODx.grid.Grid,{
             if (input && value != ''){
                 if (value == '_empty'){
                     value = '';
-                }                
+                }
                 input.setValue(value);
                 this.getStore().baseParams[filterDefaults[i].name]=value;
                 refresh = true;
-            } 
+            }
         }
         if (refresh){
             this.getBottomToolbar().changePage(1);
-            this.refresh();            
-        }            
-                   
+            this.refresh();
+        }
+
     }
     ,getSelectedAsList: function() {
         var sels = this.getSelectionModel().getSelections();
@@ -131,17 +131,17 @@ Ext.extend(MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal},MODx.grid.Grid,{
         cs = Ext.util.Format.substr(cs,1,cs.length-1);
         return cs;
     }
-    
+
     {/literal}{$customconfigs.gridfunctions}{literal}
 
     ,setWinPosition: function(x,y){
     var win = Ext.getCmp('{/literal}modx-window-mi-grid-update-{$win_id}{literal}');
-    win.setPosition(x,y);     
-        
-    }	
-                	     
-	,loadWin: function(btn,e,action,tempParams) {
-        var storeParams = Ext.util.JSON.encode(this.store.baseParams); 
+    win.setPosition(x,y);
+
+    }
+
+    ,loadWin: function(btn,e,action,tempParams) {
+        var storeParams = Ext.util.JSON.encode(this.store.baseParams);
         var resource_id = '{/literal}{$resource.id}{literal}';
         var tempParams = tempParams || null;
         var input_prefix = Ext.id(null,'inp_');
@@ -153,23 +153,23 @@ Ext.extend(MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal},MODx.grid.Grid,{
             return;
         }
         {/if}
-        {literal}        
-       
+        {literal}
+
         if (action == 'a'){
            var object_id = 'new';
         }else{
            var object_id = this.menu.record.id;
            //var object_id = 3;
         }
-        
+
         var isnew = (action == 'u') ? '0':'1';
         var isduplicate = (action == 'd') ? '1':'0';
         var win_xtype = 'modx-window-tv-dbitem-update-{/literal}{$win_id}{literal}';
-		this.windows[win_xtype] = null;
+        this.windows[win_xtype] = null;
         /*
         if (this.windows[win_xtype]){
-			this.windows[win_xtype].fp.autoLoad.params.tv_id='{/literal}{$tv_id}{literal}';
-			this.windows[win_xtype].fp.autoLoad.params.resource_id=resource_id;
+            this.windows[win_xtype].fp.autoLoad.params.tv_id='{/literal}{$tv_id}{literal}';
+            this.windows[win_xtype].fp.autoLoad.params.resource_id=resource_id;
             this.windows[win_xtype].fp.autoLoad.params.co_id=co_id;
             this.windows[win_xtype].fp.autoLoad.params.input_prefix=input_prefix;
             this.windows[win_xtype].fp.autoLoad.params.configs=this.config.configs;
@@ -179,50 +179,50 @@ Ext.extend(MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal},MODx.grid.Grid,{
             this.windows[win_xtype].fp.autoLoad.params.storeParams=storeParams;
             this.windows[win_xtype].fp.autoLoad.params.loadaction='';
             this.windows[win_xtype].fp.autoLoad.params.isnew=isnew;
-            this.windows[win_xtype].fp.autoLoad.params.isduplicate=isduplicate;            
-			this.windows[win_xtype].grid=this;
+            this.windows[win_xtype].fp.autoLoad.params.isduplicate=isduplicate;
+            this.windows[win_xtype].grid=this;
             this.windows[win_xtype].action=action;
-            
+
             //this.setWinPosition(10,10);
-            
-    	}
+
+        }
         */
         /*
         if (this.windows[win_xtype]){
              //this.windows[win_xtype].destroy();
              //console.log(this.windows[win_xtype]);
-             delete this.windows[win_xtype]; 
+             delete this.windows[win_xtype];
         }
         */
-        
+
         //console.log('loadwin');
-        
-		this.loadWindow(btn,e,{
+
+        this.loadWindow(btn,e,{
             xtype: win_xtype
-			,grid: this
+            ,grid: this
             ,action: action
             ,baseParams : {
-			    action: 'mgr/migxdb/fields',
+                action: 'mgr/migxdb/fields',
                 parent_window: '{/literal}{$window_id}{literal}',
                 win_id: '{/literal}{$win_id}{literal}',
-				tv_id: '{/literal}{$tv_id}{literal}',
-				tv_name: '{/literal}{$tv->name}{literal}',
-				'class_key': 'modDocument',
+                tv_id: '{/literal}{$tv_id}{literal}',
+                tv_name: '{/literal}{$tv->name}{literal}',
+                'class_key': 'modDocument',
                 'wctx':'{/literal}{$myctx}{literal}',
                 object_id: object_id,
                 configs: this.config.configs,
                 resource_id : resource_id,
                 co_id : co_id,
                 isnew : isnew,
-                isduplicate : isduplicate,                
+                isduplicate : isduplicate,
                 tempParams: tempParams,
                 storeParams: storeParams,
                 input_prefix: input_prefix,
                 loadaction:''
-			}
+            }
         });
     }
-	,loadIframeWin: function(btn,e,tpl,action) {
+    ,loadIframeWin: function(btn,e,tpl,action) {
         var resource_id = '{/literal}{$resource.id}{literal}';
         var co_id = '{/literal}{$connected_object_id}{literal}';
         var url = '{/literal}{$config.connectorUrl}{literal}';
@@ -245,21 +245,21 @@ Ext.extend(MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal},MODx.grid.Grid,{
            var object_id = 'new';
         }else{
            var object_id = this.menu.record.id;
-        }        
+        }
         if (jsonvarkey == ''){
             jsonvarkey = 'migx_outputvalue';
         }
         var object_id_field = null;
-        
+
         var win_xtype = 'modx-window-mi-iframe-{/literal}{$win_id}{literal}';
-		if (this.windows[win_xtype]){
-			//this.windows[win_xtype].fp.autoLoad.params.tv_id='{/literal}{$tv_id}{literal}';
-			//this.windows[win_xtype].fp.autoLoad.params.tv_name='{/literal}{$tv->name}{literal}';
-		    //this.windows[win_xtype].fp.autoLoad.params.itemid=index;
+        if (this.windows[win_xtype]){
+            //this.windows[win_xtype].fp.autoLoad.params.tv_id='{/literal}{$tv_id}{literal}';
+            //this.windows[win_xtype].fp.autoLoad.params.tv_name='{/literal}{$tv->name}{literal}';
+            //this.windows[win_xtype].fp.autoLoad.params.itemid=index;
             //this.windows[win_xtype].fp.autoLoad.params.record_json=json;
             this.windows[win_xtype].object_id = object_id;
             this.windows[win_xtype].src = url;
-			this.windows[win_xtype].json=items;
+            this.windows[win_xtype].json=items;
             this.windows[win_xtype].jsonvarkey=jsonvarkey;
             this.windows[win_xtype].action=action;
             this.windows[win_xtype].resource_id=resource_id;
@@ -272,14 +272,14 @@ Ext.extend(MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal},MODx.grid.Grid,{
             co_id_field = Ext.get('migx_iframewin_co_id_{/literal}{$win_id}{literal}');
             co_id_field.dom.value = co_id;
             store_params_field = Ext.get('migx_iframewin_store_params_{/literal}{$win_id}{literal}');
-            store_params_field.dom.value = storeParams;            
-		}
-		this.loadWindow(btn,e,{
+            store_params_field.dom.value = storeParams;
+        }
+        this.loadWindow(btn,e,{
             xtype: win_xtype
             ,src: url
             ,jsonvarkey:jsonvarkey
             ,json: items
-			,grid: this
+            ,grid: this
             ,action: action
             ,object_id: object_id
             ,resource_id: resource_id
@@ -288,33 +288,33 @@ Ext.extend(MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal},MODx.grid.Grid,{
             ,title: windowtitle
             ,iframeTpl: tpl
         });
-    }    		        
+    }
     ,getMenu: function() {
-		var n = this.menu.record;
+        var n = this.menu.record;
         var m = [];
-        {/literal}{$customconfigs.gridcontextmenus}{literal}   
+        {/literal}{$customconfigs.gridcontextmenus}{literal}
         if (m.length > 0) {
             //this.addContextMenuItem(m);
-        }             	        
-		return m;
+        }
+        return m;
     }
     ,renderRowActions:function(v,md,rec) {
         var n = rec.data;
-        var m = [];	   
-        {/literal}{$customconfigs.gridcolumnbuttons}{literal} 
+        var m = [];
+        {/literal}{$customconfigs.gridcolumnbuttons}{literal}
         rec.data.column_actions = m;
         rec.data.column_value = v;
         return this.tplRowActions.apply(rec.data);
-	}    
+    }
     ,setSelectedRecords:function(){
-        this.selected_records = this.getSelectionModel().getSelections();    
-    }        
-	,updateSelected: function(column,value,stopRefresh){
-        var col = null;	 
-        var rec = null;        
+        this.selected_records = this.getSelectionModel().getSelections();
+    }
+    ,updateSelected: function(column,value,stopRefresh){
+        var col = null;
+        var rec = null;
         if (column && column.dataIndex){
             col = column.dataIndex;
- 		    var records = this.selected_records;
+             var records = this.selected_records;
             if (records){
                 for(i = 0; i < records.length; i++) {
                     rec = records[i];
@@ -326,7 +326,7 @@ Ext.extend(MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal},MODx.grid.Grid,{
                         ,params: {
                             action: 'mgr/migxdb/update'
                             ,data: Ext.util.JSON.encode(item)
-				            ,configs: this.configs
+                            ,configs: this.configs
                             ,resource_id: this.resource_id
                             ,co_id: this.co_id
                             ,object_id: object_id
@@ -338,35 +338,35 @@ Ext.extend(MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal},MODx.grid.Grid,{
                                 fn:function(){
                                     this.refresh();
                                 }
-                                ,scope:this} 
+                                ,scope:this}
                         }
                     });
                  }
              }
          }
          if (stopRefresh){
-            
+
          }else{
-                  
+
          }
 
-         MODx.fireResourceFormChange();   
-	} 
-	,onClickGrid: function(e){
+         MODx.fireResourceFormChange();
+    }
+    ,onClickGrid: function(e){
         var t = e.getTarget();
         var elm = t.className.split(' ')[0];
-		if(elm == 'controlBtn') {
+        if(elm == 'controlBtn') {
             var handler = t.className.split(' ')[2];
             var col = t.className.split(' ')[3];
-			var record = this.getSelectionModel().getSelected();
+            var record = this.getSelectionModel().getSelected();
             this.menu.record = record;
             var fn = eval(handler);
             fn = fn.createDelegate(this);
             fn(null,e,col);
             e.stopEvent();
- 		}
-	} 
-  
+         }
+    }
+
 });
 Ext.reg('modx-grid-multitvdbgrid-{/literal}{$win_id}{literal}',MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal});
 
@@ -374,7 +374,7 @@ MODx.MigxTreeCombo = function(config) {
     config = config || {};
     Ext.applyIf(config,{
 
-      
+
     });
     MODx.MigxTreeCombo.superclass.constructor.call(this,config);
     this.options = config;
@@ -384,17 +384,17 @@ MODx.MigxTreeCombo = function(config) {
     this.addEvents({
         success: true
         ,failure: true
-		//,hide:true
-		//,show:true
+        //,hide:true
+        //,show:true
     });
-    //this.renderIframe();	
+    //this.renderIframe();
 };
 
 Ext.extend(MODx.MigxTreeCombo,Ext.form.ComboBox,{
     extStore: null,
     tree: null,
     treeId: 0,
-    
+
        initComponent: function() {
             this.treeId = Ext.id();
             this.focusLinkId = Ext.id();
@@ -417,25 +417,25 @@ Ext.extend(MODx.MigxTreeCombo,Ext.form.ComboBox,{
             var root = this.root;
             var listeners = this.treelisteners;
             this.tree = new Ext.tree.TreePanel({
-			    loader: new Ext.tree.TreeLoader({
-			        dataUrl: '{/literal}{$config.connectorUrl}{literal}',
+                loader: new Ext.tree.TreeLoader({
+                    dataUrl: '{/literal}{$config.connectorUrl}{literal}',
                     baseParams: baseParams
-			    }),
+                }),
                 root: root,
-			    autoHeight: true
-		    });
+                autoHeight: true
+            });
 
             this.on('expand', this.onExpand);
             this.tree.on('beforeclick', this.onNodeclick, this);
             this.tree.on('expandnode', this.onBeforeexpandnode, this);
             this.tree.on('collapsenode', this.onBeforecollapsenode, this);
             MODx.MigxTreeCombo.superclass.initComponent.apply(this, arguments);
-    },        
+    },
 
 
     onExpand: function() {
 
-        this.tree.render(this.treeId);        
+        this.tree.render(this.treeId);
         this.tree.getRootNode().expand();
     },
 
@@ -446,7 +446,7 @@ Ext.extend(MODx.MigxTreeCombo,Ext.form.ComboBox,{
     onBeforecollapsenode: function(node) {
         //expand combobox again, if collapse-icon was clicked
         this.expand();
-    },               
+    },
     onNodeclick: function(node,e) {
         //this.setValue(node.text);
         this.setValue(node.id);
@@ -461,16 +461,16 @@ Ext.extend(MODx.MigxTreeCombo,Ext.form.ComboBox,{
 Ext.reg('migx-treecombo', MODx.MigxTreeCombo);
 
 var MIGx = MIGx || {};
- 
+
 MIGx.updateGrid = function() {
     /*
     var grids = this.el.select('.tv_modx-grid-multitvgrid_items');
     grids.each(function(grid){
         Ext.getCmp(grid.id).getView().refresh();
     });
-    */  
+    */
 };
- 
+
 Ext.ComponentMgr.onAvailable('modx-grid-multitvdbgrid-{/literal}{$win_id}{literal}', function() {
     /*
     if (this.configs == 'memsnippets'){
@@ -490,7 +490,7 @@ Ext.ComponentMgr.onAvailable('modx-grid-multitvdbgrid-{/literal}{$win_id}{litera
         }
     });
     */
-     
+
 });
 
 

--- a/core/components/migx/templates/mgr/grids/default.grid.tpl
+++ b/core/components/migx/templates/mgr/grids/default.grid.tpl
@@ -50,7 +50,7 @@ MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal} = function(config) {
     isModified : false,    
     sm: this.sm,
 	viewConfig: {
-        emptyText: 'No items found',
+        emptyText: '[[%migx.noitems]]',
         forceFit: true,
 		autoFill: true
     },

--- a/core/components/migx/templates/mgr/grids/dragdrop.grid.tpl
+++ b/core/components/migx/templates/mgr/grids/dragdrop.grid.tpl
@@ -12,10 +12,10 @@
     var renderer = null;
     var pageSize = '{/literal}{$customconfigs.gridpagesize}{literal}';
     if (pageSize != ''){
-        config.pageSize=parseInt(pageSize); 
+        config.pageSize=parseInt(pageSize);
     }
-   
-	for(i = 0; i <  config.columns.length; i++) {
+
+    for(i = 0; i <  config.columns.length; i++) {
         renderer = config.columns[i]['renderer'];
         if (typeof renderer != 'undefined'){
             config.columns[i]['renderer'] = {fn:eval(renderer),scope:this};
@@ -26,7 +26,7 @@
             if (this[editor]){
                 config.columns[i]['editor'] = this[editor](config.columns[i]);
             }
-        }         
+        }
         cols.push(config.columns[i]);
         pc.push(config.pathconfigs[i]);
     }
@@ -43,7 +43,7 @@
     remoteSort: true,
     ddGroup:'{/literal}{$tv->id}{literal}_gridDD',
     primaryKey: 'id',
-    isModified : false,
+    isModified: false,
     enableDragDrop: true, // enable drag and drop of grid rows
     sm: this.sm,
     viewConfig: {
@@ -64,7 +64,7 @@
 
     var ddrow = new Ext.dd.DropTarget(grid.container, {
     overClass: 'x-grid3-row-dd', //HAS NO EFFECT
-    ddGroup : '{/literal}{$tv->id}{literal}_gridDD',
+    ddGroup: '{/literal}{$tv->id}{literal}_gridDD',
     copy:false,
 
     notifyOver : function(dd, e, data){
@@ -238,13 +238,13 @@
 
     ,setWinPosition: function(x,y){
     var win = Ext.getCmp('{/literal}modx-window-mi-grid-update-{$win_id}{literal}');
-    win.setPosition(x,y);     
-        
-    }	
-                	     
-	,loadWin: function(btn,e,action,tempParams) {
-        
-        var storeParams = Ext.util.JSON.encode(this.store.baseParams); 
+    win.setPosition(x,y);
+
+    }
+
+    ,loadWin: function(btn,e,action,tempParams) {
+
+        var storeParams = Ext.util.JSON.encode(this.store.baseParams);
         var resource_id = '{/literal}{$resource.id}{literal}';
         var tempParams = tempParams || null;
         var input_prefix = Ext.id(null,'inp_');
@@ -254,22 +254,22 @@
             alert (_('migx.save_resource'));
             return;
         }
-        {/literal}{/if}{literal}        
-       
+        {/literal}{/if}{literal}
+
         if (action == 'a'){
            var object_id = 'new';
         }else{
            var object_id = this.menu.record.id;
         }
-        
+
         var isnew = (action == 'u') ? '0':'1';
         var isduplicate = (action == 'd') ? '1':'0';
         var win_xtype = 'modx-window-tv-dbitem-update-{/literal}{$win_id}{literal}';
-		this.windows[win_xtype] = null;
+        this.windows[win_xtype] = null;
         /*
         if (this.windows[win_xtype]){
-			this.windows[win_xtype].fp.autoLoad.params.tv_id='{/literal}{$tv_id}{literal}';
-			this.windows[win_xtype].fp.autoLoad.params.resource_id=resource_id;
+            this.windows[win_xtype].fp.autoLoad.params.tv_id='{/literal}{$tv_id}{literal}';
+            this.windows[win_xtype].fp.autoLoad.params.resource_id=resource_id;
             this.windows[win_xtype].fp.autoLoad.params.co_id=co_id;
             this.windows[win_xtype].fp.autoLoad.params.input_prefix=input_prefix;
             this.windows[win_xtype].fp.autoLoad.params.configs=this.config.configs;
@@ -279,45 +279,45 @@
             this.windows[win_xtype].fp.autoLoad.params.storeParams=storeParams;
             this.windows[win_xtype].fp.autoLoad.params.loadaction='';
             this.windows[win_xtype].fp.autoLoad.params.isnew=isnew;
-            this.windows[win_xtype].fp.autoLoad.params.isduplicate=isduplicate;            
-			this.windows[win_xtype].grid=this;
+            this.windows[win_xtype].fp.autoLoad.params.isduplicate=isduplicate;
+            this.windows[win_xtype].grid=this;
             this.windows[win_xtype].action=action;
-            
+
             //this.setWinPosition(10,10);
-            
-    	}
+
+        }
         */
         /*
         if (this.windows[win_xtype]){
              //this.windows[win_xtype].destroy();
              //console.log(this.windows[win_xtype]);
-             delete this.windows[win_xtype]; 
+             delete this.windows[win_xtype];
         }
         */
-        
+
         //console.log('loadwin');
-        
-		this.loadWindow(btn,e,{
+
+        this.loadWindow(btn,e,{
             xtype: win_xtype
-			,grid: this
+            ,grid: this
             ,action: action
             ,baseParams : {
-			    action: 'mgr/migxdb/fields',
-				tv_id: '{/literal}{$tv_id}{literal}',
-				tv_name: '{/literal}{$tv->name}{literal}',
-				'class_key': 'modDocument',
+                action: 'mgr/migxdb/fields',
+                tv_id: '{/literal}{$tv_id}{literal}',
+                tv_name: '{/literal}{$tv->name}{literal}',
+                'class_key': 'modDocument',
                 'wctx':'{/literal}{$myctx}{literal}',
                 object_id: object_id,
                 configs: this.config.configs,
                 resource_id : resource_id,
                 co_id : co_id,
                 isnew : isnew,
-                isduplicate : isduplicate,                
+                isduplicate : isduplicate,
                 tempParams: tempParams,
                 storeParams: storeParams,
                 input_prefix: input_prefix,
                 loadaction:''
-			}
+            }
         });
     }
     ,loadIframeWin: function(btn,e,tpl,action) {
@@ -386,21 +386,21 @@
     }
     ,renderRowActions:function(v,md,rec) {
         var n = rec.data;
-        var m = [];	   
-        {/literal}{$customconfigs.gridcolumnbuttons}{literal} 
+        var m = [];
+        {/literal}{$customconfigs.gridcolumnbuttons}{literal}
         rec.data.column_actions = m;
         rec.data.column_value = v;
         return this.tplRowActions.apply(rec.data);
-	}    
+    }
     ,setSelectedRecords:function(){
-        this.selected_records = this.getSelectionModel().getSelections();    
-    }        
-	,updateSelected: function(column,value,stopRefresh){
-        var col = null;	 
-        var rec = null;        
+        this.selected_records = this.getSelectionModel().getSelections();
+    }
+    ,updateSelected: function(column,value,stopRefresh){
+        var col = null;
+        var rec = null;
         if (column && column.dataIndex){
             col = column.dataIndex;
- 		    var records = this.selected_records;
+             var records = this.selected_records;
             if (records){
                 for(i = 0; i < records.length; i++) {
                     rec = records[i];
@@ -412,7 +412,7 @@
                         ,params: {
                             action: 'mgr/migxdb/update'
                             ,data: Ext.util.JSON.encode(item)
-				            ,configs: this.configs
+                            ,configs: this.configs
                             ,resource_id: this.resource_id
                             ,co_id: this.co_id
                             ,object_id: object_id
@@ -424,35 +424,35 @@
                                 fn:function(){
                                     this.refresh();
                                 }
-                                ,scope:this} 
+                                ,scope:this}
                         }
                     });
                  }
              }
          }
          if (stopRefresh){
-            
+
          }else{
-                  
+
          }
 
-         MODx.fireResourceFormChange();   
-	} 
-	,onClickGrid: function(e){
+         MODx.fireResourceFormChange();
+    }
+    ,onClickGrid: function(e){
         var t = e.getTarget();
         var elm = t.className.split(' ')[0];
-		if(elm == 'controlBtn') {
+        if(elm == 'controlBtn') {
             var handler = t.className.split(' ')[2];
             var col = t.className.split(' ')[3];
-			var record = this.getSelectionModel().getSelected();
+            var record = this.getSelectionModel().getSelected();
             this.menu.record = record;
             var fn = eval(handler);
             fn = fn.createDelegate(this);
             fn(null,e,col);
             e.stopEvent();
- 		}
-	} 
-  
+         }
+    }
+
 });
 Ext.reg('modx-grid-multitvdbgrid-{/literal}{$win_id}{literal}',MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal});
 

--- a/core/components/migx/templates/mgr/grids/dragdrop.grid.tpl
+++ b/core/components/migx/templates/mgr/grids/dragdrop.grid.tpl
@@ -47,7 +47,7 @@
     enableDragDrop: true, // enable drag and drop of grid rows
     sm: this.sm,
     viewConfig: {
-    emptyText: 'No items found',
+    emptyText: '[[%migx.noitems]]',
     forceFit: true,
     sm: new Ext.grid.RowSelectionModel({singleSelect:false}),
     autoFill: true

--- a/core/components/migx/templates/mgr/grids/dragdrop.grid.tpl
+++ b/core/components/migx/templates/mgr/grids/dragdrop.grid.tpl
@@ -47,10 +47,11 @@
     enableDragDrop: true, // enable drag and drop of grid rows
     sm: this.sm,
     viewConfig: {
-    emptyText: '[[%migx.noitems]]',
-    forceFit: true,
-    sm: new Ext.grid.RowSelectionModel({singleSelect:false}),
-    autoFill: true
+        emptyText: '[[%migx.noitems]]',
+        deferEmptyText: false,
+        forceFit: true,
+        sm: new Ext.grid.RowSelectionModel({singleSelect:false}),
+        autoFill: true
     },
     listeners: {
     "render": {

--- a/core/components/migx/templates/mgr/grids/grouping.grid.tpl
+++ b/core/components/migx/templates/mgr/grids/grouping.grid.tpl
@@ -2,7 +2,7 @@
 
 MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal} = function(config) {
     config = config || {};
-	//console.log(config);
+    //console.log(config);
     this.sm = new Ext.grid.CheckboxSelectionModel();
 
     // define grid columns in a separate variable
@@ -11,57 +11,57 @@ MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal} = function(config) {
     // add empty pathconfig (source) to array to match number of col in renderimage
     var pc=[''];
     var renderer = null;
-	for(i = 0; i <  config.columns.length; i++) {
+    for(i = 0; i <  config.columns.length; i++) {
         renderer = config.columns[i]['renderer'];
         if (typeof renderer != 'undefined'){
             config.columns[i]['renderer'] = {fn:eval(renderer),scope:this};
         }
         cols.push(config.columns[i]);
         pc.push(config.pathconfigs[i]);
-        
+
     }
-    config.pathconfigs = pc; 
-    config.columns=cols;    
+    config.pathconfigs = pc;
+    config.columns=cols;
     Ext.applyIf(config,{
-	autoHeight: true,
+    autoHeight: true,
     collapsible: true,
-	resizable: true,
+    resizable: true,
     loadMask: true,
     paging: true,
-    
+
     grouping:true,
     groupBy: 'content_de',
     sortBy: 'pos',
-    
+
     autosave: false,
     remoteSort: true,
     primaryKey: 'id',
-    isModified : false,    
+    isModified: false,
     sm: this.sm,
-	viewConfig: {
+    viewConfig: {
         emptyText: '[[%migx.noitems]]',
         deferEmptyText: false,
         forceFit: true,
-		autoFill: true
+        autoFill: true
     },
-    url : config.url,
-    baseParams: { 
+    url: config.url,
+    baseParams: {
         action: 'mgr/migxdb/getlist',
         configs: config.configs,
         resource_id: config.resource_id,
         object_id: config.object_id,
         'HTTP_MODAUTH': config.auth
     },
-    fields: [],    
+    fields: [],
     columns: [], // define grid columns in a separate variable
-    tbar: [{/literal}{$customconfigs.tbar}{literal}]        
+    tbar: [{/literal}{$customconfigs.tbar}{literal}]
     });
-	
+
     MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal}.superclass.constructor.call(this,config)
     this.view.groupTextTpl = '<div class="statisticGroup">{text}</div>';
     this._makeTemplates();
     this.getStore().pathconfigs=config.pathconfigs;
-    this.on('click', this.onClickGrid, this);   
+    this.on('click', this.onClickGrid, this);
 
 };
 Ext.extend(MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal},MODx.grid.Grid,{
@@ -70,19 +70,19 @@ Ext.extend(MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal},MODx.grid.Grid,{
     }
     ,_makeTemplates: function() {
         this.tplRowActions = new Ext.XTemplate('<tpl for="."><div class="migx-actions-column">'
-										    +'<h3 class="main-column">{column_value}</h3>'
-												+'<tpl if="column_actions">'
-													+'<ul class="actions">'
+                                            +'<h3 class="main-column">{column_value}</h3>'
+                                                +'<tpl if="column_actions">'
+                                                    +'<ul class="actions">'
                                                         +'<tpl for="column_actions">'
-                                                            +'<tpl if="typeof (className) != '+"'undefined'"+'">'   
-														    +'<li><a href="#" class="controlBtn {className} {handler}">{text}</a></li>'
+                                                            +'<tpl if="typeof (className) != '+"'undefined'"+'">'
+                                                            +'<li><a href="#" class="controlBtn {className} {handler}">{text}</a></li>'
                                                           +'</tpl>'
-													    +'</tpl>'
+                                                        +'</tpl>'
                                                     +'</ul>'
-												+'</tpl>'
-											+'</div></tpl>',{
-			compiled: true
-		});
+                                                +'</tpl>'
+                                            +'</div></tpl>',{
+            compiled: true
+        });
     }
     ,getSelectedAsList: function() {
         var sels = this.getSelectionModel().getSelections();
@@ -95,12 +95,12 @@ Ext.extend(MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal},MODx.grid.Grid,{
         cs = Ext.util.Format.substr(cs,1,cs.length-1);
         return cs;
     }
-    
+
     {/literal}{$customconfigs.gridfunctions}{literal}
-	
-                	     
-	,loadWin: function(btn,e,action,tempParams) {
-        
+
+
+    ,loadWin: function(btn,e,action,tempParams) {
+
         var resource_id = '{/literal}{$resource.id}{literal}';
         var tempParams = tempParams || null;
         var co_id = '{/literal}{$connected_object_id}{literal}';
@@ -109,76 +109,76 @@ Ext.extend(MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal},MODx.grid.Grid,{
             alert (_('migx.save_resource'));
             return;
         }
-        {/literal}{/if}{literal}        
-       
+        {/literal}{/if}{literal}
+
         if (action == 'a'){
            var object_id = 'new';
         }else{
            var object_id = this.menu.record.id;
         }
-        
+
         var isnew = (action == 'u') ? '0':'1';
-        
- 		
+
+
         var win_xtype = 'modx-window-tv-dbitem-update-{/literal}{$win_id}{literal}';
-		if (this.windows[win_xtype]){
-			this.windows[win_xtype].fp.autoLoad.params.tv_id='{/literal}{$tv->id}{literal}';
-			this.windows[win_xtype].fp.autoLoad.params.resource_id=resource_id;
+        if (this.windows[win_xtype]){
+            this.windows[win_xtype].fp.autoLoad.params.tv_id='{/literal}{$tv->id}{literal}';
+            this.windows[win_xtype].fp.autoLoad.params.resource_id=resource_id;
             this.windows[win_xtype].fp.autoLoad.params.co_id=co_id;
             this.windows[win_xtype].fp.autoLoad.params.configs=this.config.configs;
             this.windows[win_xtype].fp.autoLoad.params.tv_name='{/literal}{$tv->name}{literal}';
             this.windows[win_xtype].fp.autoLoad.params.object_id=object_id;
             this.windows[win_xtype].fp.autoLoad.params.tempParams=tempParams;
-			this.windows[win_xtype].grid=this;
+            this.windows[win_xtype].grid=this;
             this.windows[win_xtype].action=action;
-           
-		}
-		this.loadWindow(btn,e,{
+
+        }
+        this.loadWindow(btn,e,{
             xtype: win_xtype
-			,grid: this
+            ,grid: this
             ,action: action
-            
+
             ,baseParams : {
-			    action: 'mgr/migxdb/fields',
-				tv_id: '{/literal}{$tv->id}{literal}',
-				tv_name: '{/literal}{$tv->name}{literal}',
-				'class_key': 'modDocument',
+                action: 'mgr/migxdb/fields',
+                tv_id: '{/literal}{$tv->id}{literal}',
+                tv_name: '{/literal}{$tv->name}{literal}',
+                'class_key': 'modDocument',
                 'wctx':'{/literal}{$myctx}{literal}',
                 object_id: object_id,
                 configs: this.config.configs,
                 resource_id : resource_id,
                 co_id : co_id,
                 tempParams: tempParams
-			}
+            }
         });
     }
     ,getMenu: function() {
-		var n = this.menu.record;
+        var n = this.menu.record;
         var m = [];
-        {/literal}{$customconfigs.gridcontextmenus}{literal}        	        
-		return m;
+        {/literal}{$customconfigs.gridcontextmenus}{literal}
+        return m;
     }
     ,renderRowActions:function(v,md,rec) {
         var n = rec.data;
-        var m = [];	   
-        {/literal}{$customconfigs.gridcolumnbuttons}{literal} 
+        var m = [];
+        {/literal}{$customconfigs.gridcolumnbuttons}{literal}
         rec.data.column_actions = m;
         rec.data.column_value = v;
         return this.tplRowActions.apply(rec.data);
-	} 
-	,onClickGrid: function(e){
-		
+    }
+    ,onClickGrid: function(e){
+
         var t = e.getTarget();
-		var elm = t.className.split(' ')[0];
-		if(elm == 'controlBtn') {
-			var handler = t.className.split(' ')[2];
-			var record = this.getSelectionModel().getSelected();
+        var elm = t.className.split(' ')[0];
+        if(elm == 'controlBtn') {
+            var handler = t.className.split(' ')[2];
+            var record = this.getSelectionModel().getSelected();
             this.menu.record = record;
             var fn = eval(handler);
             fn = fn.createDelegate(this);
             fn(null,e);
- 		}
-	}    
+         }
+    }
 });
 Ext.reg('modx-grid-multitvdbgrid-{/literal}{$win_id}{literal}',MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal});
 

--- a/core/components/migx/templates/mgr/grids/grouping.grid.tpl
+++ b/core/components/migx/templates/mgr/grids/grouping.grid.tpl
@@ -40,6 +40,7 @@ MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal} = function(config) {
     sm: this.sm,
 	viewConfig: {
         emptyText: '[[%migx.noitems]]',
+        deferEmptyText: false,
         forceFit: true,
 		autoFill: true
     },

--- a/core/components/migx/templates/mgr/grids/grouping.grid.tpl
+++ b/core/components/migx/templates/mgr/grids/grouping.grid.tpl
@@ -39,7 +39,7 @@ MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal} = function(config) {
     isModified : false,    
     sm: this.sm,
 	viewConfig: {
-        emptyText: 'No items found',
+        emptyText: '[[%migx.noitems]]',
         forceFit: true,
 		autoFill: true
     },

--- a/core/components/migx/templates/mgr/grids/migx.grid.tpl
+++ b/core/components/migx/templates/mgr/grids/migx.grid.tpl
@@ -35,6 +35,7 @@ MODx.grid.multiTVgrid{/literal}{$tv->id}{literal} = function(config) {
     enableDragDrop: true, // enable drag and drop of grid rows
     viewConfig: {
         emptyText: '[[%migx.noitems]]',
+        deferEmptyText: false,
         sm: new Ext.grid.RowSelectionModel({
             singleSelect:true
             }),

--- a/core/components/migx/templates/mgr/grids/migx.grid.tpl
+++ b/core/components/migx/templates/mgr/grids/migx.grid.tpl
@@ -34,7 +34,7 @@ MODx.grid.multiTVgrid{/literal}{$tv->id}{literal} = function(config) {
     ddGroup:'{/literal}{$tv->id}{literal}_gridDD',
     enableDragDrop: true, // enable drag and drop of grid rows
     viewConfig: {
-        emptyText: 'No items found',
+        emptyText: '[[%migx.noitems]]',
         sm: new Ext.grid.RowSelectionModel({
             singleSelect:true
             }),

--- a/core/components/migx/templates/mgr/grids/migx.grid.tpl
+++ b/core/components/migx/templates/mgr/grids/migx.grid.tpl
@@ -27,8 +27,8 @@ MODx.grid.multiTVgrid{/literal}{$tv->id}{literal} = function(config) {
     autoHeight: true,
     collapsible: true,
     resizable: true,
-    store: 	new Ext.data.JsonStore({
-        fields : config.fields
+    store: new Ext.data.JsonStore({
+        fields: config.fields
     }), // define the data store in a separate variable
     loadMask: true,
     ddGroup:'{/literal}{$tv->id}{literal}_gridDD',
@@ -38,7 +38,7 @@ MODx.grid.multiTVgrid{/literal}{$tv->id}{literal} = function(config) {
         deferEmptyText: false,
         sm: new Ext.grid.RowSelectionModel({
             singleSelect:true
-            }),
+        }),
         forceFit: true,
         autoFill: true
     },
@@ -124,7 +124,7 @@ MODx.grid.multiTVgrid{/literal}{$tv->id}{literal} = function(config) {
                                 for(i = 0; i <  rows.length; i++) {
                                 ds.remove(ds.getById(rows[i].id));
                                 }
-     							ds.insert(cindex,data.selections);
+                                 ds.insert(cindex,data.selections);
                                 sm.clearSelections();
                              }
                              MODx.fireResourceFormChange();
@@ -244,7 +244,7 @@ Ext.extend(MODx.grid.multiTVgrid{/literal}{$tv->id}{literal},MODx.grid.LocalGrid
 
         this.autoinc = 0;
         for(i = 0; i <  items.length; i++) {
- 		    item = items[i];
+             item = items[i];
             if (item.MIGX_id){
                 if (parseInt(item.MIGX_id)  > this.autoinc){
                     this.autoinc = item.MIGX_id;
@@ -393,7 +393,7 @@ Ext.extend(MODx.grid.multiTVgrid{/literal}{$tv->id}{literal},MODx.grid.LocalGrid
                         Ext.get('tv{/literal}{$tv->id}{literal}').dom.value = Ext.util.JSON.encode(items);
                         this.autoinc = 0;
                         for(i = 0; i <  items.length; i++) {
- 		                    item = items[i];
+                             item = items[i];
                             if (item.MIGX_id){
 
                                 if (parseInt(item.MIGX_id)  > this.autoinc){
@@ -534,7 +534,7 @@ Ext.extend(MODx.grid.multiTVgrid{/literal}{$tv->id}{literal},MODx.grid.LocalGrid
         }
         var win_xtype = 'modx-window-mi-iframe-{/literal}{$win_id}{literal}';
         var object_id_field = null;
-    	if (this.windows[win_xtype]){
+        if (this.windows[win_xtype]){
             //this.windows[win_xtype].fp.autoLoad.params.tv_id='{/literal}{$tv->id}{literal}';
             //this.windows[win_xtype].fp.autoLoad.params.tv_name='{/literal}{$tv->name}{literal}';
             //this.windows[win_xtype].fp.autoLoad.params.itemid=index;
@@ -595,7 +595,7 @@ Ext.extend(MODx.grid.multiTVgrid{/literal}{$tv->id}{literal},MODx.grid.LocalGrid
         var n = this.menu.record;
         var m = [];
         {/literal}{$customconfigs.gridcontextmenus}{literal}
-    	return m;
+        return m;
     }
     ,renderRowActions:function(v,md,rec) {
         var n = rec.data;
@@ -613,7 +613,7 @@ Ext.extend(MODx.grid.multiTVgrid{/literal}{$tv->id}{literal},MODx.grid.LocalGrid
         var rec = null;
         if (column && column.dataIndex){
             col = column.dataIndex;
- 		    var records = this.selected_records;
+             var records = this.selected_records;
             if (records){
                 for(i = 0; i < records.length; i++) {
                 rec = records[i];
@@ -654,7 +654,7 @@ Ext.extend(MODx.grid.multiTVgrid{/literal}{$tv->id}{literal},MODx.grid.LocalGrid
 
         var griddata=this.store.data;
         for(i = 0; i <  griddata.length; i++) {
- 			items.push(griddata.items[i].json);
+             items.push(griddata.items[i].json);
         }
 
         if (this.call_collectmigxitems || this.call_collectmigxitems_once){
@@ -679,7 +679,7 @@ Ext.extend(MODx.grid.multiTVgrid{/literal}{$tv->id}{literal},MODx.grid.LocalGrid
                         Ext.get('tv{/literal}{$tv->id}{literal}').dom.value = Ext.util.JSON.encode(items);
                         this.autoinc = 0;
                         for(i = 0; i <  items.length; i++) {
- 		                    item = items[i];
+                             item = items[i];
                             if (item.MIGX_id){
                                 if (parseInt(item.MIGX_id)  > this.autoinc){
                                     this.autoinc = item.MIGX_id;
@@ -707,7 +707,7 @@ Ext.extend(MODx.grid.multiTVgrid{/literal}{$tv->id}{literal},MODx.grid.LocalGrid
            Ext.get('tv{/literal}{$tv->id}{literal}').dom.value = '';
         }
         }
-    	return;
+        return;
     }
     ,onClickGrid: function(e){
 
@@ -728,7 +728,7 @@ Ext.extend(MODx.grid.multiTVgrid{/literal}{$tv->id}{literal},MODx.grid.LocalGrid
             fn = fn.createDelegate(this);
             fn(null,e,col);
             e.stopEvent();
- 		}
+         }
     }
 });
 Ext.reg('modx-grid-multitvgrid-{/literal}{$tv->id}{literal}',MODx.grid.multiTVgrid{/literal}{$tv->id}{literal});

--- a/core/components/migx/templates/mgr/grids/quipcomments.grid.tpl
+++ b/core/components/migx/templates/mgr/grids/quipcomments.grid.tpl
@@ -5,7 +5,7 @@ MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal} = function(config) {
     this.sm = new Ext.grid.CheckboxSelectionModel();
     this.ident = config.ident || 'quip-'+Ext.id();
 
-    var quipconfig = Ext.util.JSON.decode('{/literal}{$customconfigs.quipconfig}{literal}');    
+    var quipconfig = Ext.util.JSON.decode('{/literal}{$customconfigs.quipconfig}{literal}');
     config.url = quipconfig.connectorUrl;
     config.columns = [this.sm,{
             header: _('quip.comment')
@@ -29,17 +29,17 @@ MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal} = function(config) {
             ,width: 100
             ,renderer: this._renderUrl
         }];
-        
-    config.fields = ['id','author','username','body','createdon','name','approved','deleted','ip','url','pagetitle','comments','website','email','cls'];    
+
+    config.fields = ['id','author','username','body','createdon','name','approved','deleted','ip','url','pagetitle','comments','website','email','cls'];
 
     Ext.applyIf(config,{
         url: config.url
-        ,baseParams: { 
+        ,baseParams: {
             action: 'mgr/comment/getlist'
             ,thread: config.thread || null
             ,family: config.family || null
         }
-        ,fields: config.fields 
+        ,fields: config.fields
         ,paging: true
         ,autosave: false
         ,remoteSort: true
@@ -118,10 +118,10 @@ Ext.extend(MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal},MODx.grid.Grid,{
         },this);
     }
     ,clearFilter: function() {
-    	var s = this.getStore();
+        var s = this.getStore();
         s.baseParams.search = '';
         Ext.getCmp(this.ident+'-tf-search').reset();
-    	this.getBottomToolbar().changePage(1);
+        this.getBottomToolbar().changePage(1);
         this.refresh();
     }
     ,search: function(tf,newValue,oldValue) {
@@ -147,7 +147,7 @@ Ext.extend(MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal},MODx.grid.Grid,{
         var cls = 'quip-posted';
         if (!rec.data.approved) cls += ' quip-unapproved';
         if (rec.data.deleted) cls += ' quip-deleted';
-        
+
         return '<div class="'+cls+'">'+v+'<br /><span class="quip-ip">'+rec.data.ip+'</span></div>';
     }
     ,toggleDeleted: function(btn,e) {
@@ -166,7 +166,7 @@ Ext.extend(MODx.grid.multiTVdbgrid{/literal}{$win_id}{literal},MODx.grid.Grid,{
     ,approveSelected: function(btn,e) {
         var cs = this.getSelectedAsList();
         if (cs === false) return false;
-        
+
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
@@ -440,8 +440,8 @@ Ext.reg('modx-grid-multitvdbgrid-{/literal}{$win_id}{literal}',MODx.grid.multiTV
 
 Quip.window.UpdateComment = function(config) {
     config = config || {};
-    var quipconfig = Ext.util.JSON.decode('{/literal}{$customconfigs.quipconfig}{literal}');    
-    config.url = quipconfig.connectorUrl;    
+    var quipconfig = Ext.util.JSON.decode('{/literal}{$customconfigs.quipconfig}{literal}');
+    config.url = quipconfig.connectorUrl;
     Ext.applyIf(config,{
         title: _('quip.comment_update')
         ,url: Quip.config.connector_url
@@ -456,17 +456,17 @@ Quip.window.UpdateComment = function(config) {
             xtype: 'textfield'
             ,fieldLabel: _('quip.name')
             ,name: 'name'
-            ,anchor: '90%'        
+            ,anchor: '90%'
         },{
             xtype: 'textfield'
             ,fieldLabel: _('quip.email')
             ,name: 'email'
-            ,anchor: '90%'        
+            ,anchor: '90%'
         },{
             xtype: 'textfield'
             ,fieldLabel: _('quip.website')
             ,name: 'website'
-            ,anchor: '90%'        
+            ,anchor: '90%'
         },{
             xtype: 'statictextfield'
             ,fieldLabel: _('quip.ip')


### PR DESCRIPTION
1) Added output of lexicons for empty lines in the grid, otherwise it was always output in English.

![migx_empty_grid](https://github.com/Bruno17/MIGX/assets/12523676/d4e2b7d1-b0a3-4047-ab14-054cd7b01176)

2) Added display of empty text on initialization - https://github.com/Bruno17/MIGX/issues/432

3) And corrected the code tabulation.