### PR TITLE
Fix CSV Import for MODX 3

### DIFF
--- a/core/components/migx/configs/grid/grid.config.inc.php
+++ b/core/components/migx/configs/grid/grid.config.inc.php
@@ -845,6 +845,7 @@ $gridfunctions['this.importCsvMigx'] = "
     importCsvMigx: function(data) {
         var recordIndex = 'none';
         var pathname = data.pathname;
+        var fullRelativeUrl = data.fullRelativeUrl;
         if (this.menu.recordIndex == 0){
             recordIndex = 0; 
         }else{
@@ -861,6 +862,7 @@ $gridfunctions['this.importCsvMigx'] = "
                 ,items: Ext.get('tv' + tv_id).dom.value
                 ,record_index: recordIndex
                 ,pathname: pathname
+                ,fullRelativeUrl: fullRelativeUrl
             }
             ,listeners: {
                 'success': {fn:function(res){
@@ -914,5 +916,3 @@ exportImportItem: function(btn,e) {
   this.loadWin(btn,e,this.menu.recordIndex,'export_import_migxitem');
 }  
 ";
-
-

--- a/core/components/migx/processors/mgr/default/importcsvmigx.php
+++ b/core/components/migx/processors/mgr/default/importcsvmigx.php
@@ -24,6 +24,11 @@ if (!empty($hooksnippet_getcustomconfigs)){
 $reference_field = $modx->getOption('reference_field', $scriptProperties, 'id');
 $items = $modx->getOption('items', $scriptProperties, '');
 $pathname = $modx->getOption('pathname', $scriptProperties, '');
+if ($modx->migx->is_modx3()) {
+    // In MODX 3, 'pathname' is not an absolute path, but relative to the media source
+    $base_path = $modx->getOption('base_path', null, MODX_BASE_PATH);
+    $pathname = $base_path . $modx->getOption('fullRelativeUrl', $scriptProperties, '');
+}
 $items = !empty($items) ? $this->modx->fromJson($items) : array();
 
 


### PR DESCRIPTION
The action-button "importcsvmigx" doesn't work correctly in MODX 3, because the file path that `modx-browser` returns is not an absolute path anymore.

---

Related topic in the MODX forum:
https://community.modx.com/t/how-do-i-import-data-from-excel-to-getimagelist/7385/6