### PR TITLE
Fix ERROR with sql_mode=only_full_group_by

### DIFF
--- a/core/components/migx/model/migx/migx.class.php
+++ b/core/components/migx/model/migx/migx.class.php
@@ -47,6 +47,24 @@ class Migx {
     function __construct(modX & $modx, array $config = array()) {
         $this->modx = &$modx;
 
+        // ===============
+        // INJECTED PATCH
+        // Disable ONLY_FULL_GROUP_BY mode for all MIGX requests
+        static $sql_mode_disabled = false;
+        if (!$sql_mode_disabled) {
+            try {
+                $modx->query("SET SESSION sql_mode = (SELECT REPLACE(@@sql_mode, 'ONLY_FULL_GROUP_BY', ''))");
+                if ($modx->getOption('migx.debug', null, false)) {
+                    $modx->log(modX::LOG_LEVEL_INFO, 'MIGX: ONLY_FULL_GROUP_BY mode disabled for compatibility');
+                }
+                $sql_mode_disabled = true;
+            } catch (Exception $e) {
+                $modx->log(modX::LOG_LEVEL_ERROR, 'MIGX: Failed to disable ONLY_FULL_GROUP_BY mode: ' . $e->getMessage());
+            }
+        }
+        // END IJECTED PATCH
+        // =================
+
         $packageName = 'migx';
         $packagepath = $this->findPackagePath($packageName); 
         $modelpath = $packagepath . 'model/';

--- a/core/components/migx/model/migx/migx.class.php
+++ b/core/components/migx/model/migx/migx.class.php
@@ -221,7 +221,12 @@ class Migx {
         }
 
         if (!empty($groupby)) {
-            $c->groupby($groupby);
+            // Fix ERROR "SELECT list is not in GROUP BY clause" with sql_mode=only_full_group_by
+            if ($groupby == 'name') {
+                $c->groupby(array('id', 'name'));
+            } else {
+                $c->groupby($groupby);
+            }
         }
 
         //set "total" placeholder for getPage


### PR DESCRIPTION
MODX Revo 2.7.1-pl
---
ERROR @ /xxxxxx/xpdo/om/xpdoobject.class.php : 240 Error 42000 executing statement: Array ( [0] => 42000 [1] => 1055 [2] => Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'xxxxxx.migxConfig.id' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by