### PR TITLE
Fix error for sql_mode=only_full_group_by

### DIFF
--- a/core/components/migx/configs/migxconfigs.config.inc.php
+++ b/core/components/migx/configs/migxconfigs.config.inc.php
@@ -99,6 +99,7 @@ if (!empty($_REQUEST['tempParams']) && $_REQUEST['tempParams'] == 'export_import
     $prefixes[] = 'Custom Prefix==1';
     
     $c = $this->modx->newQuery($classname);
+    $c->select(['MIN(id) AS id','category']);
     $c->sortby('category');
     $c->groupby('category');
     $categorylist = array();

--- a/core/components/migx/processors/mgr/default/getcombo.php
+++ b/core/components/migx/processors/mgr/default/getcombo.php
@@ -110,7 +110,7 @@ switch ($mode) {
             $c->leftjoin($joinclass, $joinalias);
             //$c->select($modx->getSelectColumns($joinclass, $joinalias, $joinalias . '_'));
         }
-        $c->select($c->getAlias() . '.id, ' . $idfield . ' as combo_id, ' . $textfield . ' as combo_name');
+        $c->select('MIN(' . $c->getAlias() . '.id) as id, ' . $idfield . ' as combo_id, ' . $textfield . ' as combo_name');
         break;
 }
 
@@ -131,6 +131,7 @@ if ($execute) {
         $c->where($fwhere);
     }
 
+    $c->groupby('combo_id');
     $c->groupby('combo_name');
     $c->sortby($sort, $dir);
     $stmt = $c->prepare();


### PR DESCRIPTION
If **ONLY_FULL_GROUP_BY** is used in the sql_mode setting for MySQL, MIGX generates error messages like this:
```
[2025-05-12 09:26:32] (ERROR @ ...\core\vendor\xpdo\xpdo\src\xPDO\Om\xPDOObject.php : 227) Error 42000 executing statement: 
Array
(
    [0] => 42000
    [1] => 1055
    [2] => Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'modx305c.migxConfig.id' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by
)
```
This PR should fix the issue for most use cases.

---

This is an alternative solution to #441, #443 etc.

---

If GROUP BY is used in other places (e.g. in the field "Group By" (tab "MIGXdb-Settings" of the MIGX config) or as a property for the snippet "migxLoopCollection") then the issue will have to be fixed there (by setting "Select Fields" or the snippet property `&selectfields`).